### PR TITLE
refactor: extract entrypoint script from inline Dockerfile printf block

### DIFF
--- a/src/docker.rs
+++ b/src/docker.rs
@@ -7,6 +7,9 @@ use std::sync::{Arc, Mutex};
 /// The base Dockerfile embedded at compile time.
 pub const DOCKERFILE: &str = include_str!("../templates/Dockerfile");
 
+/// The container entrypoint script embedded at compile time.
+pub const ENTRYPOINT_SH: &str = include_str!("../templates/entrypoint.sh");
+
 /// The jq stream-display filter embedded at compile time.
 pub const STREAM_DISPLAY_JQ: &str = include_str!("../templates/stream_display.jq");
 
@@ -97,21 +100,16 @@ pub fn build_base_image(rebuild: bool) -> Result<()> {
 
     eprintln!("Building {BASE_IMAGE} image…");
 
-    let mut child = Command::new("docker")
-        .args(["build", "-t", BASE_IMAGE, "-"])
-        .stdin(Stdio::piped())
-        .spawn()
+    let ctx = tempfile::tempdir().context("failed to create build context tempdir")?;
+    std::fs::write(ctx.path().join("Dockerfile"), DOCKERFILE)
+        .context("failed to write Dockerfile to build context")?;
+    std::fs::write(ctx.path().join("entrypoint.sh"), ENTRYPOINT_SH)
+        .context("failed to write entrypoint.sh to build context")?;
+
+    let status = Command::new("docker")
+        .args(["build", "-t", BASE_IMAGE, &ctx.path().to_string_lossy()])
+        .status()
         .context("failed to spawn `docker build`")?;
-
-    {
-        use std::io::Write;
-        let stdin = child.stdin.as_mut().expect("stdin piped");
-        stdin
-            .write_all(DOCKERFILE.as_bytes())
-            .context("failed to write Dockerfile to docker stdin")?;
-    }
-
-    let status = child.wait().context("docker build did not complete")?;
     if !status.success() {
         bail!(
             "docker build exited with code {}",

--- a/templates/Dockerfile
+++ b/templates/Dockerfile
@@ -34,5 +34,6 @@ ENV CI=true
 
 # Entrypoint: configure git credentials from GH_TOKEN and git identity from
 # GIT_AUTHOR_* env vars, run optional before-each.sh, then launch Claude Code.
-RUN printf '#!/bin/bash\nset -e\nif [ -n "${GH_TOKEN}" ]; then\n  git config --global credential.helper store\n  echo "https://oauth2:${GH_TOKEN}@github.com" > "${HOME}/.git-credentials"\n  chmod 600 "${HOME}/.git-credentials"\nfi\n_name="${GIT_AUTHOR_NAME:-Capsule}"\n_email="${GIT_AUTHOR_EMAIL:-capsule@localhost}"\ngit config --global user.name "${_name}"\ngit config --global user.email "${_email}"\nif [ -x /home/claude/before-each.sh ]; then\n  echo "── Running before-each.sh ────────────────────────────────────"\n  /home/claude/before-each.sh\n  echo "── before-each.sh complete ───────────────────────────────────"\nfi\ncat /home/claude/prompt.txt | claude --dangerously-skip-permissions --model "${CAPSULE_MODEL:-claude-sonnet-4-6}" -p --verbose --output-format stream-json\n' > /home/claude/entrypoint.sh && chmod +x /home/claude/entrypoint.sh
+COPY entrypoint.sh /home/claude/entrypoint.sh
+RUN chmod +x /home/claude/entrypoint.sh
 ENTRYPOINT ["/home/claude/entrypoint.sh"]

--- a/templates/entrypoint.sh
+++ b/templates/entrypoint.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -e
+if [ -n "${GH_TOKEN}" ]; then
+  git config --global credential.helper store
+  echo "https://oauth2:${GH_TOKEN}@github.com" > "${HOME}/.git-credentials"
+  chmod 600 "${HOME}/.git-credentials"
+fi
+_name="${GIT_AUTHOR_NAME:-Capsule}"
+_email="${GIT_AUTHOR_EMAIL:-capsule@localhost}"
+git config --global user.name "${_name}"
+git config --global user.email "${_email}"
+if [ -x /home/claude/before-each.sh ]; then
+  echo "── Running before-each.sh ────────────────────────────────────"
+  /home/claude/before-each.sh
+  echo "── before-each.sh complete ───────────────────────────────────"
+fi
+cat /home/claude/prompt.txt | claude --dangerously-skip-permissions --model "${CAPSULE_MODEL:-claude-sonnet-4-6}" -p --verbose --output-format stream-json

--- a/tests/docker.rs
+++ b/tests/docker.rs
@@ -3,7 +3,7 @@ mod common;
 use capsule::docker::{
     build_base_image, build_derived_image, build_docker_args, contains_auth_failure,
     contains_no_more_tasks, derived_image_name, detect_compose_network, run_iteration,
-    IterationOutcome, RunConfig, DOCKERFILE, STREAM_DISPLAY_JQ,
+    IterationOutcome, RunConfig, DOCKERFILE, ENTRYPOINT_SH, STREAM_DISPLAY_JQ,
 };
 use common::requires_docker;
 use serial_test::serial;
@@ -18,6 +18,22 @@ fn embedded_dockerfile_is_non_empty() {
     assert!(
         DOCKERFILE.contains("FROM archlinux"),
         "Dockerfile must start from archlinux base"
+    );
+}
+
+#[test]
+fn embedded_entrypoint_sh_is_non_empty() {
+    assert!(
+        !ENTRYPOINT_SH.is_empty(),
+        "embedded entrypoint.sh must not be empty"
+    );
+    assert!(
+        ENTRYPOINT_SH.contains("#!/bin/bash"),
+        "entrypoint.sh must be a bash script"
+    );
+    assert!(
+        ENTRYPOINT_SH.contains("CAPSULE_MODEL"),
+        "entrypoint.sh must reference CAPSULE_MODEL"
     );
 }
 


### PR DESCRIPTION
## Summary
- Extracts the container entrypoint script from an escaped inline `RUN printf` block into `templates/entrypoint.sh` as a first-class file
- Embeds `entrypoint.sh` at compile time via `include_str!` as `ENTRYPOINT_SH` alongside the existing `DOCKERFILE` constant
- Rewrites `build_base_image` to use a tempdir build context (instead of stdin pipe) since `COPY` requires a real context directory

Closes #30

## Test plan
- [ ] `cargo test` passes (new `embedded_entrypoint_sh_is_non_empty` test added)
- [ ] Dockerfile and entrypoint.sh are both visible in diffs going forward
- [ ] `build_base_image` integration tests still pass with Docker available