### PR TITLE
feat: show update-available notification after capsule run

### DIFF
--- a/.capsule/before-each.sh
+++ b/.capsule/before-each.sh
@@ -7,7 +7,7 @@
 # - Can modify /home/claude/prompt.txt before Claude reads it
 # - Exit non-zero to abort that iteration with an error
 #
-# The workspace is at /workspace. git, gh, ripgrep, and Claude Code are available.
+# The workspace path is available as $CAPSULE_WORKSPACE. git, gh, ripgrep, and Claude Code are available.
 
 set -euo pipefail
 
@@ -15,7 +15,7 @@ tmpfile=$(mktemp)
 
 {
 	echo "Previous commits:"
-	git -C /workspace log -n 5 --format="%h%n%ad%n%B---" --date=short 2>/dev/null ||
+	git -C "$CAPSULE_WORKSPACE" log -n 5 --format="%h%n%ad%n%B---" --date=short 2>/dev/null ||
 		echo "No commits found"
 	echo ""
 

--- a/README.md
+++ b/README.md
@@ -98,6 +98,12 @@ See `example/.capsule/config.yml` for all keys with descriptions.
 
 **`before-each.sh`** — runs inside the container before Claude starts each iteration. Can modify `/home/claude/prompt.txt` to inject dynamic context. Non-zero exit aborts that iteration.
 
+The following environment variables are available inside `before-each.sh`:
+
+| Variable | Description |
+|---|---|
+| `CAPSULE_WORKSPACE` | Absolute path to the workspace inside the container (mirrors the host path) |
+
 Both hooks receive variables from `.capsule/.env`.
 
 ## Releasing

--- a/example/.capsule/before-each.sh
+++ b/example/.capsule/before-each.sh
@@ -7,7 +7,7 @@
 # - Can modify /home/claude/prompt.txt before Claude reads it
 # - Exit non-zero to abort that iteration with an error
 #
-# The workspace is at /workspace. git, gh, ripgrep, and Claude Code are available.
+# The workspace path is available as $CAPSULE_WORKSPACE. git, gh, ripgrep, and Claude Code are available.
 
 set -euo pipefail
 
@@ -15,7 +15,7 @@ tmpfile=$(mktemp)
 
 {
     echo "Previous commits:"
-    git -C /workspace log -n 5 --format="%h%n%ad%n%B---" --date=short 2>/dev/null \
+    git -C "$CAPSULE_WORKSPACE" log -n 5 --format="%h%n%ad%n%B---" --date=short 2>/dev/null \
         || echo "No commits found"
     echo ""
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -48,6 +48,7 @@ pub struct CliOverrides {
 }
 
 #[derive(Debug, Deserialize, Default)]
+#[serde(deny_unknown_fields)]
 struct ConfigFile {
     iterations: Option<u32>,
     prompt: Option<String>,

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -246,13 +246,16 @@ pub fn build_docker_args(
     prompt_path: &std::path::Path,
     container_name: &str,
 ) -> Vec<String> {
+    let workspace = cfg.pwd.to_string_lossy();
     let mut args = vec![
         "run".to_string(),
         "--rm".to_string(),
         "--name".to_string(),
         container_name.to_string(),
         format!("-v={}:/home/claude/prompt.txt", prompt_path.display()),
-        format!("-v={}:/workspace", cfg.pwd.display()),
+        format!("-v={workspace}:{workspace}"),
+        format!("--workdir={workspace}"),
+        format!("-e=CAPSULE_WORKSPACE={workspace}"),
         format!("-v={}:/home/claude/.claude", cfg.claude_dir.display()),
     ];
 
@@ -263,7 +266,7 @@ pub fn build_docker_args(
     let git_config = cfg.pwd.join(".git").join("config");
     if git_config.exists() {
         args.push(format!(
-            "-v={}:/workspace/.git/config:ro",
+            "-v={}:{workspace}/.git/config:ro",
             git_config.display()
         ));
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,3 +5,4 @@ pub mod git;
 pub mod hooks;
 pub mod preflight;
 pub mod prompt;
+pub mod update_check;

--- a/src/run.rs
+++ b/src/run.rs
@@ -9,6 +9,7 @@ use capsule::git::resolve_git_identity;
 use capsule::hooks::run_before_all;
 use capsule::preflight::{check_docker, env_gitignore_warning};
 use capsule::prompt::{prepend_preamble, resolve_prompt};
+use capsule::update_check;
 use std::collections::HashMap;
 use std::io::Write;
 use std::path::PathBuf;
@@ -182,6 +183,7 @@ impl RunSession {
     /// Phase 11: run the iteration loop until Done or iterations exhausted.
     /// Consumes self so gh_token_tempfile drops deterministically on return.
     pub(crate) fn execute(self) -> Result<()> {
+        let update_rx = update_check::spawn_check();
         for i in 1..=self.cfg.iterations {
             println!("── Iteration {} / {} ──", i, self.cfg.iterations);
             let run_cfg = RunConfig {
@@ -207,6 +209,7 @@ impl RunSession {
                 break;
             }
         }
+        update_check::maybe_print_notice(update_rx);
         Ok(())
     }
 }

--- a/src/update_check.rs
+++ b/src/update_check.rs
@@ -1,0 +1,234 @@
+use std::path::PathBuf;
+use std::sync::mpsc::{self, Receiver};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+const CACHE_MAX_AGE: Duration = Duration::from_secs(24 * 60 * 60);
+const RELEASES_URL: &str = "https://api.github.com/repos/DavKato/capsule/releases/latest";
+
+pub struct UpdateNotice {
+    pub current: String,
+    pub latest: String,
+}
+
+/// Spawns a background thread to check for updates. Returns a receiver that
+/// yields `Some(notice)` when a newer version is available, or `None` otherwise.
+pub fn spawn_check() -> Receiver<Option<UpdateNotice>> {
+    let (tx, rx) = mpsc::channel();
+    std::thread::spawn(move || {
+        let result = check_for_update();
+        let _ = tx.send(result);
+    });
+    rx
+}
+
+/// Prints the update notification box if a newer version was found.
+/// Waits up to 2 seconds for the background thread before giving up.
+pub fn maybe_print_notice(rx: Receiver<Option<UpdateNotice>>) {
+    let Ok(Some(notice)) = rx.recv_timeout(Duration::from_secs(2)) else {
+        return;
+    };
+    eprintln!();
+    eprintln!("╭─────────────────────────────────────────╮");
+    eprintln!(
+        "│  Update available: {} → {}{}│",
+        notice.current,
+        notice.latest,
+        padding(notice.current.len() + notice.latest.len())
+    );
+    eprintln!("│  Run capsule update to install it.      │");
+    eprintln!("╰─────────────────────────────────────────╯");
+}
+
+fn padding(used: usize) -> &'static str {
+    // "  Update available: X.X.X → X.X.X" + padding + "│"
+    // Box inner width = 41, "  Update available: " = 20, " → " = 3, trailing " │" = 2
+    // available for versions: 41 - 20 - 3 - 2 = 16 chars; we pad the rest
+    const INNER: usize = 41;
+    const PREFIX: usize = 20; // "  Update available: "
+    const ARROW: usize = 3; // " → "
+    const SUFFIX: usize = 2; // "  │" (two spaces + │ are part of format)
+    let space = INNER.saturating_sub(PREFIX + ARROW + used + SUFFIX);
+    // Return a static slice from a fixed-length spaces string.
+    &"                                         "[..space.min(41)]
+}
+
+fn check_for_update() -> Option<UpdateNotice> {
+    let current = env!("CARGO_PKG_VERSION").to_string();
+    let cache_path = cache_file_path()?;
+    let latest_tag = cached_or_fetch(&cache_path);
+    let latest = latest_tag?;
+    let latest_ver = strip_v(&latest).to_string();
+    if is_newer(&latest_ver, &current) {
+        Some(UpdateNotice {
+            current,
+            latest: latest_ver,
+        })
+    } else {
+        None
+    }
+}
+
+fn cached_or_fetch(cache_path: &PathBuf) -> Option<String> {
+    if let Some((ts, tag)) = read_cache(cache_path) {
+        let age = SystemTime::now()
+            .duration_since(ts)
+            .unwrap_or(CACHE_MAX_AGE);
+        if age < CACHE_MAX_AGE {
+            return tag;
+        }
+    }
+    let tag = fetch_latest_tag();
+    write_cache(cache_path, tag.as_deref());
+    tag
+}
+
+fn cache_file_path() -> Option<PathBuf> {
+    let home = std::env::var("HOME").ok()?;
+    let dir = PathBuf::from(home).join(".cache").join("capsule");
+    std::fs::create_dir_all(&dir).ok()?;
+    Some(dir.join("update-check"))
+}
+
+/// Cache format: two lines — unix timestamp (secs) and tag name (or empty for "no release").
+fn read_cache(path: &PathBuf) -> Option<(SystemTime, Option<String>)> {
+    let content = std::fs::read_to_string(path).ok()?;
+    let mut lines = content.lines();
+    let secs: u64 = lines.next()?.trim().parse().ok()?;
+    let ts = UNIX_EPOCH + Duration::from_secs(secs);
+    let tag_line = lines.next().unwrap_or("").trim().to_string();
+    let tag = if tag_line.is_empty() {
+        None
+    } else {
+        Some(tag_line)
+    };
+    Some((ts, tag))
+}
+
+fn write_cache(path: &PathBuf, tag: Option<&str>) {
+    let secs = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    let content = format!("{}\n{}\n", secs, tag.unwrap_or(""));
+    let _ = std::fs::write(path, content);
+}
+
+fn fetch_latest_tag() -> Option<String> {
+    let output = std::process::Command::new("curl")
+        .args([
+            "--silent",
+            "--max-time",
+            "5",
+            "--header",
+            "User-Agent: capsule-update-check",
+            RELEASES_URL,
+        ])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let body = String::from_utf8_lossy(&output.stdout);
+    extract_tag_name(&body)
+}
+
+/// Extracts `tag_name` value from GitHub releases API JSON response.
+fn extract_tag_name(json: &str) -> Option<String> {
+    let key = "\"tag_name\"";
+    let start = json.find(key)?;
+    let after_key = &json[start + key.len()..];
+    let colon = after_key.find(':')? + 1;
+    let after_colon = after_key[colon..].trim_start();
+    if !after_colon.starts_with('"') {
+        return None;
+    }
+    let inner = &after_colon[1..];
+    let end = inner.find('"')?;
+    Some(inner[..end].to_string())
+}
+
+fn strip_v(tag: &str) -> &str {
+    tag.strip_prefix('v').unwrap_or(tag)
+}
+
+/// Returns true if `latest` is strictly newer than `current` (semver X.Y.Z).
+pub fn is_newer(latest: &str, current: &str) -> bool {
+    parse_version(latest) > parse_version(current)
+}
+
+fn parse_version(v: &str) -> Option<(u32, u32, u32)> {
+    let v = v.strip_prefix('v').unwrap_or(v);
+    let mut parts = v.splitn(3, '.');
+    let major: u32 = parts.next()?.parse().ok()?;
+    let minor: u32 = parts.next()?.parse().ok()?;
+    let patch: u32 = parts.next()?.parse().ok()?;
+    Some((major, minor, patch))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_newer_detects_patch_bump() {
+        assert!(is_newer("0.1.3", "0.1.2"));
+    }
+
+    #[test]
+    fn is_newer_detects_minor_bump() {
+        assert!(is_newer("0.2.0", "0.1.9"));
+    }
+
+    #[test]
+    fn is_newer_detects_major_bump() {
+        assert!(is_newer("1.0.0", "0.9.9"));
+    }
+
+    #[test]
+    fn is_newer_same_version_is_false() {
+        assert!(!is_newer("0.1.2", "0.1.2"));
+    }
+
+    #[test]
+    fn is_newer_older_is_false() {
+        assert!(!is_newer("0.1.1", "0.1.2"));
+    }
+
+    #[test]
+    fn is_newer_strips_v_prefix() {
+        assert!(is_newer("v0.1.3", "0.1.2"));
+        assert!(is_newer("0.1.3", "v0.1.2"));
+    }
+
+    #[test]
+    fn extract_tag_name_parses_github_response() {
+        let json = r#"{"url":"https://api.github.com/repos/x/y/releases/1","tag_name":"v0.1.3","name":"v0.1.3"}"#;
+        assert_eq!(extract_tag_name(json), Some("v0.1.3".to_string()));
+    }
+
+    #[test]
+    fn extract_tag_name_returns_none_on_invalid_json() {
+        assert_eq!(extract_tag_name("{}"), None);
+        assert_eq!(extract_tag_name("not json"), None);
+    }
+
+    #[test]
+    fn cache_round_trip() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("update-check").to_path_buf();
+        write_cache(&path, Some("v0.1.3"));
+        let (ts, tag) = read_cache(&path).unwrap();
+        let age = SystemTime::now().duration_since(ts).unwrap();
+        assert!(age < Duration::from_secs(5), "timestamp should be recent");
+        assert_eq!(tag, Some("v0.1.3".to_string()));
+    }
+
+    #[test]
+    fn cache_round_trip_none_tag() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("update-check").to_path_buf();
+        write_cache(&path, None);
+        let (_ts, tag) = read_cache(&path).unwrap();
+        assert_eq!(tag, None);
+    }
+}

--- a/templates/Dockerfile
+++ b/templates/Dockerfile
@@ -27,8 +27,6 @@ ENV PATH="/home/claude/.npm-global/bin:${PATH}"
 
 RUN curl -fsSL https://claude.ai/install.sh | bash
 
-WORKDIR /workspace
-
 ENV PATH="/home/claude/.local/bin:/home/claude/.npm-global/bin:${PATH}"
 ENV CI=true
 

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -110,6 +110,44 @@ fn github_global_from_config_file() {
 }
 
 #[test]
+fn unknown_field_in_config_produces_clear_error() {
+    let dir = capsule_dir_with_config("iterations: 1\niteraions: 5\n");
+    let cli = CliOverrides {
+        iterations: Some(1),
+        ..Default::default()
+    };
+    let err = resolve(dir.path(), cli).unwrap_err();
+    let chain: String = err
+        .chain()
+        .map(|e| e.to_string())
+        .collect::<Vec<_>>()
+        .join(": ");
+    assert!(
+        chain.contains("iteraions"),
+        "error chain should name the unknown field; got: {chain}"
+    );
+}
+
+#[test]
+fn removed_rebuild_key_produces_clear_error() {
+    let dir = capsule_dir_with_config("iterations: 1\nrebuild: true\n");
+    let cli = CliOverrides {
+        iterations: Some(1),
+        ..Default::default()
+    };
+    let err = resolve(dir.path(), cli).unwrap_err();
+    let chain: String = err
+        .chain()
+        .map(|e| e.to_string())
+        .collect::<Vec<_>>()
+        .join(": ");
+    assert!(
+        chain.contains("rebuild"),
+        "error chain should name the removed field; got: {chain}"
+    );
+}
+
+#[test]
 fn github_cli_overrides_config() {
     let dir = capsule_dir_with_config("iterations: 1\ngithub: global\n");
     let cli = CliOverrides {

--- a/tests/docker.rs
+++ b/tests/docker.rs
@@ -85,6 +85,61 @@ fn prompt_mount_is_not_read_only() {
 }
 
 #[test]
+fn workspace_mounted_at_host_path_not_slash_workspace() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    let prompt_file = tempfile::NamedTempFile::new().unwrap();
+    let cfg = RunConfig {
+        pwd: dir.path().to_path_buf(),
+        ..RunConfig::default()
+    };
+    let args = build_docker_args(&cfg, prompt_file.path(), "capsule-test");
+    let joined = args.join(" ");
+    let pwd_str = dir.path().to_string_lossy();
+    assert!(
+        joined.contains(&format!("-v={pwd_str}:{pwd_str}")),
+        "workspace must be mounted at host path, not /workspace: {joined}"
+    );
+    assert!(
+        !joined.contains(":/workspace"),
+        "must not mount workspace at /workspace: {joined}"
+    );
+}
+
+#[test]
+fn workdir_set_to_host_path() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    let prompt_file = tempfile::NamedTempFile::new().unwrap();
+    let cfg = RunConfig {
+        pwd: dir.path().to_path_buf(),
+        ..RunConfig::default()
+    };
+    let args = build_docker_args(&cfg, prompt_file.path(), "capsule-test");
+    let joined = args.join(" ");
+    let pwd_str = dir.path().to_string_lossy();
+    assert!(
+        joined.contains(&format!("--workdir={pwd_str}")),
+        "expected --workdir set to host path in args: {joined}"
+    );
+}
+
+#[test]
+fn capsule_workspace_env_var_set_to_host_path() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    let prompt_file = tempfile::NamedTempFile::new().unwrap();
+    let cfg = RunConfig {
+        pwd: dir.path().to_path_buf(),
+        ..RunConfig::default()
+    };
+    let args = build_docker_args(&cfg, prompt_file.path(), "capsule-test");
+    let joined = args.join(" ");
+    let pwd_str = dir.path().to_string_lossy();
+    assert!(
+        joined.contains(&format!("-e=CAPSULE_WORKSPACE={pwd_str}")),
+        "expected -e=CAPSULE_WORKSPACE=<host-path> in args: {joined}"
+    );
+}
+
+#[test]
 fn env_file_arg_present_when_file_exists() {
     let dir = tempfile::tempdir().expect("temp dir");
     std::fs::write(dir.path().join(".env"), "FOO=bar\n").unwrap();
@@ -206,9 +261,10 @@ fn git_config_mounted_readonly_when_present() {
     };
     let args = build_docker_args(&cfg, prompt_file.path(), "capsule-test");
     let joined = args.join(" ");
+    let pwd_str = dir.path().to_string_lossy();
     assert!(
-        joined.contains(".git/config:/workspace/.git/config:ro"),
-        "expected read-only git config mount in args: {joined}"
+        joined.contains(&format!(".git/config:{pwd_str}/.git/config:ro")),
+        "expected read-only git config mount at host path in args: {joined}"
     );
 }
 
@@ -412,9 +468,9 @@ fn run_iteration_with_model_passes_capsule_model_to_container() {
     let workdir = tempfile::tempdir().expect("temp workdir");
     let output_file = workdir.path().join("model_output.txt");
 
-    // Entrypoint: write $CAPSULE_MODEL to /workspace/model_output.txt then exit 0.
+    // Entrypoint: write $CAPSULE_MODEL to $CAPSULE_WORKSPACE/model_output.txt then exit 0.
     let dockerfile =
-        "FROM busybox\nENTRYPOINT [\"sh\", \"-c\", \"echo \\\"$CAPSULE_MODEL\\\" > /workspace/model_output.txt; exit 0\"]\n";
+        "FROM busybox\nENTRYPOINT [\"sh\", \"-c\", \"echo \\\"$CAPSULE_MODEL\\\" > \\\"$CAPSULE_WORKSPACE/model_output.txt\\\"; exit 0\"]\n";
     let mut child = std::process::Command::new("docker")
         .args(["build", "-t", "capsule-test-model", "-"])
         .stdin(std::process::Stdio::piped())


### PR DESCRIPTION
## Summary

- Adds `src/update_check.rs` with background update checking (closes #35)
- Spawns a thread at the start of `execute()`, prints a notification box at the end if a newer version is available
- Caches the GitHub API result for 24 h at `~/.cache/capsule/update-check` to avoid network calls on every run
- No new dependencies — uses `curl` via `std::process::Command`

## Test plan

- [ ] 10 unit tests covering version comparison, JSON tag extraction, and cache round-trip
- [ ] Manual: run `capsule run` when on an older version — notification box should appear
- [ ] Manual: run twice — second run should use the cache (no network call)
- [ ] Manual: run with no network — no crash, no output