### PR TITLE
feat(#58): add done verdict status + note injection module

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ pub mod env;
 pub mod git;
 pub mod hooks;
 pub mod mcp_server;
+pub mod note_block;
 pub mod preflight;
 pub mod prompt;
 pub mod stream_parser;

--- a/src/mcp_server.rs
+++ b/src/mcp_server.rs
@@ -12,6 +12,7 @@ pub fn handle_verdict_call(args: &Value) -> Value {
     let status = match status_str {
         "pass" => VerdictStatus::Pass,
         "fail" => VerdictStatus::Fail,
+        "done" => VerdictStatus::Done,
         other => {
             return json!({"ok": false, "error": format!("unknown status: {other}")});
         }
@@ -41,7 +42,7 @@ pub fn handle_message(line: &str) -> Option<String> {
                 "inputSchema": {
                     "type": "object",
                     "properties": {
-                        "status": {"type": "string", "enum": ["pass", "fail"]},
+                        "status": {"type": "string", "enum": ["pass", "fail", "done"]},
                         "notes": {"type": "string"}
                     },
                     "required": ["status"]
@@ -125,6 +126,15 @@ mod tests {
     }
 
     #[test]
+    fn valid_done_returns_ok_with_done_verdict() {
+        let args = json!({"status": "done", "notes": "loop exited"});
+        let res = handle_verdict_call(&args);
+        assert_eq!(res["ok"], true);
+        assert_eq!(res["verdict"]["status"], "done");
+        assert_eq!(res["verdict"]["notes"], "loop exited");
+    }
+
+    #[test]
     fn unknown_status_returns_error() {
         let args = json!({"status": "unknown"});
         let res = handle_verdict_call(&args);
@@ -161,6 +171,23 @@ mod tests {
         let res = handle_message(req).unwrap();
         let v: Value = serde_json::from_str(&res).unwrap();
         assert_eq!(v["result"]["tools"][0]["name"], "submit_verdict");
+    }
+
+    #[test]
+    fn tools_list_includes_done_in_status_enum() {
+        let req = r#"{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}"#;
+        let res = handle_message(req).unwrap();
+        let v: Value = serde_json::from_str(&res).unwrap();
+        let status_enum = &v["result"]["tools"][0]["inputSchema"]["properties"]["status"]["enum"];
+        let values: Vec<&str> = status_enum
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|s| s.as_str().unwrap())
+            .collect();
+        assert!(values.contains(&"pass"));
+        assert!(values.contains(&"fail"));
+        assert!(values.contains(&"done"));
     }
 
     #[test]

--- a/src/note_block.rs
+++ b/src/note_block.rs
@@ -1,0 +1,53 @@
+use crate::verdict::VerdictStatus;
+
+/// Formats a previous-stage block for injection into a stage prompt.
+/// Returns `None` when `notes` is `None` or empty.
+pub fn format(stage_name: &str, status: &VerdictStatus, notes: Option<&str>) -> Option<String> {
+    let notes = notes.filter(|n| !n.is_empty())?;
+    let status_str = match status {
+        VerdictStatus::Pass => "pass",
+        VerdictStatus::Fail => "fail",
+        VerdictStatus::Done => "done",
+    };
+    Some(format!(
+        "<previous-stage>\nStage: {stage_name}\nStatus: {status_str}\nNotes: {notes}\n</previous-stage>"
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn format_with_notes_returns_block() {
+        let out = format("review", &VerdictStatus::Pass, Some("all checks passed"));
+        let block = out.unwrap();
+        assert!(block.contains("<previous-stage>"));
+        assert!(block.contains("Stage: review"));
+        assert!(block.contains("Status: pass"));
+        assert!(block.contains("Notes: all checks passed"));
+        assert!(block.contains("</previous-stage>"));
+    }
+
+    #[test]
+    fn format_without_notes_returns_none() {
+        assert!(format("review", &VerdictStatus::Pass, None).is_none());
+    }
+
+    #[test]
+    fn format_with_empty_notes_returns_none() {
+        assert!(format("review", &VerdictStatus::Fail, Some("")).is_none());
+    }
+
+    #[test]
+    fn format_done_status_serializes_correctly() {
+        let out = format("impl", &VerdictStatus::Done, Some("loop exited")).unwrap();
+        assert!(out.contains("Status: done"));
+    }
+
+    #[test]
+    fn format_fail_status_serializes_correctly() {
+        let out = format("test", &VerdictStatus::Fail, Some("tests broke")).unwrap();
+        assert!(out.contains("Status: fail"));
+    }
+}

--- a/src/run.rs
+++ b/src/run.rs
@@ -89,7 +89,9 @@ pub(crate) enum ExitDecision {
 
 pub(crate) fn exit_decision(verdict: Option<&Verdict>) -> ExitDecision {
     match verdict {
-        Some(v) if v.status == VerdictStatus::Pass => ExitDecision::Success,
+        Some(v) if matches!(v.status, VerdictStatus::Pass | VerdictStatus::Done) => {
+            ExitDecision::Success
+        }
         Some(v) => ExitDecision::Failure(
             v.notes
                 .clone()
@@ -394,5 +396,14 @@ mod tests {
     #[test]
     fn no_verdict_is_implicit_fail() {
         assert!(matches!(exit_decision(None), ExitDecision::Failure(_)));
+    }
+
+    #[test]
+    fn done_is_success() {
+        let v = Verdict {
+            status: VerdictStatus::Done,
+            notes: Some("scope complete".to_string()),
+        };
+        assert!(matches!(exit_decision(Some(&v)), ExitDecision::Success));
     }
 }

--- a/src/verdict.rs
+++ b/src/verdict.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 pub enum VerdictStatus {
     Pass,
     Fail,
+    Done,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -58,5 +59,18 @@ mod tests {
         let v: Verdict = serde_json::from_str(r#"{"status":"pass","notes":null}"#).unwrap();
         assert_eq!(v.status, VerdictStatus::Pass);
         assert!(v.notes.is_none());
+    }
+
+    #[test]
+    fn done_with_notes_round_trips() {
+        let v = Verdict {
+            status: VerdictStatus::Done,
+            notes: Some("scope complete".to_string()),
+        };
+        let json = serde_json::to_string(&v).unwrap();
+        let back: Verdict = serde_json::from_str(&json).unwrap();
+        assert_eq!(v, back);
+        assert!(json.contains("\"done\""));
+        assert!(json.contains("\"scope complete\""));
     }
 }


### PR DESCRIPTION
## Summary

- Adds `Done` variant to `VerdictStatus` enum (`pass | fail | done`)
- Updates MCP `submit_verdict` tool to accept `"done"` status; `tools/list` enum updated
- `exit_decision` treats `Done` as `ExitDecision::Success` (scope-exit semantics)
- New `note_block` module: formats a `<previous-stage>` injection block from stage name, verdict status, and notes; returns `None` when notes are absent or empty

Closes #58
Part of #50

## Working branch

`feat/issue-50-multi-stage-pipeline`