### PR TITLE
feat(#59): parse multi-stage + loop config schema

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -2,6 +2,8 @@ use anyhow::{Context, Result};
 use serde::Deserialize;
 use std::path::{Path, PathBuf};
 
+pub const MAX_PIPELINE_ITERATIONS_DEFAULT: u32 = 1000;
+
 /// Git commit identity mode.
 #[derive(Debug, Clone, PartialEq)]
 pub enum GitIdentity {
@@ -18,6 +20,60 @@ pub enum GithubScope {
     Global,
 }
 
+/// Routing target for `on_pass`.
+#[derive(Debug, Clone, PartialEq)]
+pub enum OnPass {
+    /// Advance to next stage in the surrounding `stages:` array (default).
+    Next,
+    /// Jump to named stage.
+    Stage(String),
+    /// Terminate pipeline non-zero.
+    Exit,
+}
+
+/// Routing target for `on_fail`.
+#[derive(Debug, Clone, PartialEq)]
+pub enum OnFail {
+    /// Terminate pipeline non-zero (default).
+    Exit,
+    /// Re-run the same stage.
+    Retry,
+    /// Jump to named stage.
+    Stage(String),
+}
+
+/// One stage in a pipeline.
+#[derive(Debug, Clone, PartialEq)]
+pub struct StageConfig {
+    pub name: String,
+    pub prompt: Option<String>,
+    pub model: Option<String>,
+    pub on_pass: OnPass,
+    pub on_fail: OnFail,
+    pub max_retries: Option<u32>,
+}
+
+/// A `loop:` block containing an ordered list of stages.
+#[derive(Debug, Clone, PartialEq)]
+pub struct LoopConfig {
+    pub max_iteration: Option<u32>,
+    pub stages: Vec<StageConfig>,
+}
+
+/// An entry in the top-level `stages:` array.
+#[derive(Debug, Clone, PartialEq)]
+pub enum PipelineEntry {
+    Stage(StageConfig),
+    Loop(LoopConfig),
+}
+
+/// The parsed + validated pipeline execution graph.
+#[derive(Debug, Clone, PartialEq)]
+pub struct PipelineConfig {
+    pub entries: Vec<PipelineEntry>,
+    pub max_pipeline_iterations: u32,
+}
+
 /// Resolved configuration used by all downstream modules.
 #[derive(Debug, Clone)]
 pub struct Config {
@@ -31,6 +87,8 @@ pub struct Config {
     /// When Some, inject GH_TOKEN into the container from the specified source.
     /// When None, no token is injected.
     pub github: Option<GithubScope>,
+    /// Parsed pipeline execution graph (present for both flat-form and multi-stage configs).
+    pub pipeline: PipelineConfig,
 }
 
 /// CLI-supplied overrides. `None` means "not provided on the command line".
@@ -47,9 +105,11 @@ pub struct CliOverrides {
     pub github: Option<GithubScope>,
 }
 
+// ── Flat-form serde types ─────────────────────────────────────────────────────
+
 #[derive(Debug, Deserialize, Default)]
 #[serde(deny_unknown_fields)]
-struct ConfigFile {
+struct FlatConfigFile {
     iterations: Option<u32>,
     prompt: Option<String>,
     model: Option<String>,
@@ -58,8 +118,210 @@ struct ConfigFile {
     github: Option<String>,
 }
 
-fn parse_file(yaml: &str) -> Result<ConfigFile> {
-    serde_yaml::from_str(yaml).map_err(anyhow::Error::from)
+// ── Multi-stage serde types ───────────────────────────────────────────────────
+
+#[derive(Debug, Deserialize)]
+struct StageConfigRaw {
+    name: String,
+    prompt: Option<String>,
+    model: Option<String>,
+    on_pass: Option<String>,
+    on_fail: Option<String>,
+    max_retries: Option<u32>,
+}
+
+#[derive(Debug, Deserialize)]
+struct LoopConfigRaw {
+    max_iteration: Option<u32>,
+    stages: Vec<StageConfigRaw>,
+}
+
+#[derive(Debug, Deserialize)]
+struct LoopEntryRaw {
+    #[serde(rename = "loop")]
+    loop_block: LoopConfigRaw,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum PipelineEntryRaw {
+    Loop(LoopEntryRaw),
+    Stage(StageConfigRaw),
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct MultiStageConfigFile {
+    stages: Vec<PipelineEntryRaw>,
+    max_pipeline_iterations: Option<u32>,
+    model: Option<String>,
+    verbose: Option<bool>,
+    git_identity: Option<String>,
+    github: Option<String>,
+    /// Present to produce a clear error when combined with `stages:`.
+    iterations: Option<u32>,
+}
+
+// ── Parsing helpers ───────────────────────────────────────────────────────────
+
+enum RawConfig {
+    Flat(FlatConfigFile),
+    MultiStage(MultiStageConfigFile),
+}
+
+fn parse_config_file(yaml: &str) -> Result<RawConfig> {
+    let val: serde_yaml::Value = serde_yaml::from_str(yaml).map_err(anyhow::Error::from)?;
+    if val.get("stages").is_some() {
+        let cfg: MultiStageConfigFile = serde_yaml::from_value(val).map_err(anyhow::Error::from)?;
+        Ok(RawConfig::MultiStage(cfg))
+    } else {
+        let cfg: FlatConfigFile = serde_yaml::from_value(val).map_err(anyhow::Error::from)?;
+        Ok(RawConfig::Flat(cfg))
+    }
+}
+
+fn parse_on_pass(s: &str) -> Option<OnPass> {
+    match s {
+        "exit" => Some(OnPass::Exit),
+        name => Some(OnPass::Stage(name.to_string())),
+    }
+}
+
+fn parse_on_fail(s: &str) -> Option<OnFail> {
+    match s {
+        "exit" => Some(OnFail::Exit),
+        "retry" => Some(OnFail::Retry),
+        name => Some(OnFail::Stage(name.to_string())),
+    }
+}
+
+fn convert_stage(raw: StageConfigRaw) -> StageConfig {
+    let on_pass = raw
+        .on_pass
+        .as_deref()
+        .and_then(parse_on_pass)
+        .unwrap_or(OnPass::Next);
+    let on_fail = raw
+        .on_fail
+        .as_deref()
+        .and_then(parse_on_fail)
+        .unwrap_or(OnFail::Exit);
+    StageConfig {
+        name: raw.name,
+        prompt: raw.prompt,
+        model: raw.model,
+        on_pass,
+        on_fail,
+        max_retries: raw.max_retries,
+    }
+}
+
+fn convert_loop(raw: LoopConfigRaw) -> LoopConfig {
+    LoopConfig {
+        max_iteration: raw.max_iteration,
+        stages: raw.stages.into_iter().map(convert_stage).collect(),
+    }
+}
+
+/// Collect all stage names across all pipeline entries (including loop bodies).
+fn collect_stage_names(entries: &[PipelineEntry]) -> Vec<String> {
+    let mut names = Vec::new();
+    for entry in entries {
+        match entry {
+            PipelineEntry::Stage(s) => names.push(s.name.clone()),
+            PipelineEntry::Loop(l) => {
+                for s in &l.stages {
+                    names.push(s.name.clone());
+                }
+            }
+        }
+    }
+    names
+}
+
+/// Validate `on_pass`/`on_fail` stage references.
+fn validate_route_targets(entries: &[PipelineEntry]) -> Result<()> {
+    let all_names = collect_stage_names(entries);
+    let check = |target: &str| -> Result<()> {
+        if !all_names.contains(&target.to_string()) {
+            anyhow::bail!("config.yml: `on_pass`/`on_fail` references unknown stage `{target}`");
+        }
+        Ok(())
+    };
+    for entry in entries {
+        match entry {
+            PipelineEntry::Stage(s) => {
+                if let OnPass::Stage(ref t) = s.on_pass {
+                    check(t)?;
+                }
+                if let OnFail::Stage(ref t) = s.on_fail {
+                    check(t)?;
+                }
+            }
+            PipelineEntry::Loop(l) => {
+                for s in &l.stages {
+                    if let OnPass::Stage(ref t) = s.on_pass {
+                        check(t)?;
+                    }
+                    if let OnFail::Stage(ref t) = s.on_fail {
+                        check(t)?;
+                    }
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+fn build_pipeline_from_multi_stage(cfg: MultiStageConfigFile) -> Result<PipelineConfig> {
+    if cfg.iterations.is_some() {
+        anyhow::bail!(
+            "config.yml: `iterations:` cannot be combined with `stages:` — \
+             use `loop: {{ max_iteration: N }}` instead"
+        );
+    }
+
+    let mut entries: Vec<PipelineEntry> = Vec::new();
+    for raw_entry in cfg.stages {
+        match raw_entry {
+            PipelineEntryRaw::Loop(l) => {
+                // Reject nested loops: loop body stages must not themselves be loops.
+                // (The raw type only allows StageConfigRaw inside loops, so nested loops
+                // are structurally impossible from the YAML layer. No extra check needed.)
+                entries.push(PipelineEntry::Loop(convert_loop(l.loop_block)));
+            }
+            PipelineEntryRaw::Stage(s) => {
+                entries.push(PipelineEntry::Stage(convert_stage(s)));
+            }
+        }
+    }
+
+    validate_route_targets(&entries)?;
+
+    Ok(PipelineConfig {
+        entries,
+        max_pipeline_iterations: cfg
+            .max_pipeline_iterations
+            .unwrap_or(MAX_PIPELINE_ITERATIONS_DEFAULT),
+    })
+}
+
+fn desugar_flat_form(iterations: u32, prompt: Option<&str>) -> PipelineConfig {
+    let stage = StageConfig {
+        name: "main".to_string(),
+        prompt: prompt.map(str::to_string),
+        model: None,
+        on_pass: OnPass::Next,
+        on_fail: OnFail::Exit,
+        max_retries: None,
+    };
+    PipelineConfig {
+        entries: vec![PipelineEntry::Loop(LoopConfig {
+            max_iteration: Some(iterations),
+            stages: vec![stage],
+        })],
+        max_pipeline_iterations: MAX_PIPELINE_ITERATIONS_DEFAULT,
+    }
 }
 
 fn git_identity_from_str(s: &str) -> Option<GitIdentity> {
@@ -82,34 +344,67 @@ fn github_scope_from_str(s: &str) -> Option<GithubScope> {
 ///   CLI overrides → config file → compiled-in defaults.
 pub fn resolve(capsule_dir: &Path, cli: CliOverrides) -> Result<Config> {
     let config_path = capsule_dir.join("config.yml");
-    let file = if config_path.exists() {
-        let raw = std::fs::read_to_string(&config_path)
+    let raw = if config_path.exists() {
+        let content = std::fs::read_to_string(&config_path)
             .with_context(|| format!("reading {}", config_path.display()))?;
-        parse_file(&raw).with_context(|| format!("parsing {}", config_path.display()))?
+        Some(
+            parse_config_file(&content)
+                .with_context(|| format!("parsing {}", config_path.display()))?,
+        )
     } else {
-        ConfigFile::default()
+        None
     };
 
-    let iterations = cli.iterations.or(file.iterations).ok_or_else(|| {
-        anyhow::anyhow!("--iterations is required (no CLI flag or config.yml value found)")
-    })?;
+    let (file_flat, file_multi) = match raw {
+        Some(RawConfig::Flat(f)) => (Some(f), None),
+        Some(RawConfig::MultiStage(m)) => (None, Some(m)),
+        None => (None, None),
+    };
 
-    let prompt = cli.prompt.or_else(|| file.prompt.map(PathBuf::from));
+    // Shared fields (model, verbose, git_identity, github).
+    let file_model = file_flat
+        .as_ref()
+        .and_then(|f| f.model.clone())
+        .or_else(|| file_multi.as_ref().and_then(|m| m.model.clone()));
+    let file_verbose = file_flat
+        .as_ref()
+        .and_then(|f| f.verbose)
+        .or_else(|| file_multi.as_ref().and_then(|m| m.verbose));
+    let file_git_identity = file_flat
+        .as_ref()
+        .and_then(|f| f.git_identity.clone())
+        .or_else(|| file_multi.as_ref().and_then(|m| m.git_identity.clone()));
+    let file_github = file_flat
+        .as_ref()
+        .and_then(|f| f.github.clone())
+        .or_else(|| file_multi.as_ref().and_then(|m| m.github.clone()));
+
+    let model = cli.model.or(file_model);
+    let verbose = cli.verbose || file_verbose.unwrap_or(false);
+    let git_identity = cli
+        .git_identity
+        .or_else(|| file_git_identity.as_deref().and_then(git_identity_from_str))
+        .unwrap_or(GitIdentity::User);
+    let github = cli
+        .github
+        .or_else(|| file_github.as_deref().and_then(github_scope_from_str));
 
     let rebuild = cli.rebuild;
 
-    let model = cli.model.or(file.model);
-
-    let verbose = cli.verbose || file.verbose.unwrap_or(false);
-
-    let git_identity = cli
-        .git_identity
-        .or_else(|| file.git_identity.as_deref().and_then(git_identity_from_str))
-        .unwrap_or(GitIdentity::User);
-
-    let github = cli
-        .github
-        .or_else(|| file.github.as_deref().and_then(github_scope_from_str));
+    let (iterations, prompt, pipeline) = if let Some(multi) = file_multi {
+        let pipeline = build_pipeline_from_multi_stage(multi)
+            .with_context(|| format!("validating {}", config_path.display()))?;
+        // iterations is not applicable for multi-stage; use max_pipeline_iterations.
+        (pipeline.max_pipeline_iterations, None, pipeline)
+    } else {
+        let file_flat = file_flat.unwrap_or_default();
+        let iterations = cli.iterations.or(file_flat.iterations).ok_or_else(|| {
+            anyhow::anyhow!("--iterations is required (no CLI flag or config.yml value found)")
+        })?;
+        let prompt = cli.prompt.or_else(|| file_flat.prompt.map(PathBuf::from));
+        let pipeline = desugar_flat_form(iterations, prompt.as_ref().and_then(|p| p.to_str()));
+        (iterations, prompt, pipeline)
+    };
 
     Ok(Config {
         iterations,
@@ -120,5 +415,6 @@ pub fn resolve(capsule_dir: &Path, cli: CliOverrides) -> Result<Config> {
         verbose,
         git_identity,
         github,
+        pipeline,
     })
 }

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -1,4 +1,7 @@
-use capsule::config::{resolve, CliOverrides, Config, GitIdentity, GithubScope};
+use capsule::config::{
+    resolve, CliOverrides, Config, GitIdentity, GithubScope, OnFail, OnPass, PipelineEntry,
+    MAX_PIPELINE_ITERATIONS_DEFAULT,
+};
 use tempfile::TempDir;
 
 fn no_cli() -> CliOverrides {
@@ -157,4 +160,196 @@ fn github_cli_overrides_config() {
     };
     let cfg: Config = resolve(dir.path(), cli).unwrap();
     assert_eq!(cfg.github, Some(GithubScope::Local));
+}
+
+// ── Flat-form desugar tests ───────────────────────────────────────────────────
+
+#[test]
+fn flat_form_desugars_to_single_stage_loop() {
+    let dir = capsule_dir_with_config("iterations: 3\n");
+    let cfg: Config = resolve(dir.path(), no_cli()).unwrap();
+    assert_eq!(cfg.pipeline.entries.len(), 1);
+    let PipelineEntry::Loop(ref lp) = cfg.pipeline.entries[0] else {
+        panic!("expected Loop entry");
+    };
+    assert_eq!(lp.max_iteration, Some(3));
+    assert_eq!(lp.stages.len(), 1);
+    assert_eq!(lp.stages[0].name, "main");
+}
+
+#[test]
+fn flat_form_desugar_has_default_max_pipeline_iterations() {
+    let dir = capsule_dir_with_config("iterations: 1\n");
+    let cfg: Config = resolve(dir.path(), no_cli()).unwrap();
+    assert_eq!(
+        cfg.pipeline.max_pipeline_iterations,
+        MAX_PIPELINE_ITERATIONS_DEFAULT
+    );
+}
+
+// ── Multi-stage parsing tests ─────────────────────────────────────────────────
+
+const MULTI_STAGE_YAML: &str = "\
+stages:
+  - name: implementer
+    prompt: prompts/implement.md
+    on_fail: retry
+    max_retries: 3
+  - name: reviewer
+    prompt: prompts/review.md
+    on_fail: implementer
+max_pipeline_iterations: 500
+";
+
+#[test]
+fn multi_stage_parses_stages_and_routing() {
+    let dir = capsule_dir_with_config(MULTI_STAGE_YAML);
+    let cfg: Config = resolve(dir.path(), no_cli()).unwrap();
+    assert_eq!(cfg.pipeline.max_pipeline_iterations, 500);
+    assert_eq!(cfg.pipeline.entries.len(), 2);
+
+    let PipelineEntry::Stage(ref impl_stage) = cfg.pipeline.entries[0] else {
+        panic!("expected Stage entry");
+    };
+    assert_eq!(impl_stage.name, "implementer");
+    assert_eq!(impl_stage.on_fail, OnFail::Retry);
+    assert_eq!(impl_stage.max_retries, Some(3));
+
+    let PipelineEntry::Stage(ref rev_stage) = cfg.pipeline.entries[1] else {
+        panic!("expected Stage entry");
+    };
+    assert_eq!(rev_stage.name, "reviewer");
+    assert_eq!(rev_stage.on_fail, OnFail::Stage("implementer".to_string()));
+    assert_eq!(rev_stage.on_pass, OnPass::Next);
+}
+
+#[test]
+fn multi_stage_default_max_pipeline_iterations() {
+    let dir = capsule_dir_with_config("stages:\n  - name: only\n    prompt: p.md\n");
+    let cfg: Config = resolve(dir.path(), no_cli()).unwrap();
+    assert_eq!(
+        cfg.pipeline.max_pipeline_iterations,
+        MAX_PIPELINE_ITERATIONS_DEFAULT
+    );
+}
+
+#[test]
+fn loop_block_parses_correctly() {
+    let yaml = "\
+stages:
+  - loop:
+      max_iteration: 10
+      stages:
+        - name: planner
+          prompt: prompts/plan.md
+        - name: doer
+          prompt: prompts/do.md
+          on_fail: planner
+";
+    let dir = capsule_dir_with_config(yaml);
+    let cfg: Config = resolve(dir.path(), no_cli()).unwrap();
+    assert_eq!(cfg.pipeline.entries.len(), 1);
+    let PipelineEntry::Loop(ref lp) = cfg.pipeline.entries[0] else {
+        panic!("expected Loop entry");
+    };
+    assert_eq!(lp.max_iteration, Some(10));
+    assert_eq!(lp.stages.len(), 2);
+    assert_eq!(lp.stages[0].name, "planner");
+    assert_eq!(lp.stages[1].name, "doer");
+    assert_eq!(lp.stages[1].on_fail, OnFail::Stage("planner".to_string()));
+}
+
+#[test]
+fn on_pass_exit_parses() {
+    let yaml = "stages:\n  - name: only\n    on_pass: exit\n";
+    let dir = capsule_dir_with_config(yaml);
+    let cfg: Config = resolve(dir.path(), no_cli()).unwrap();
+    let PipelineEntry::Stage(ref s) = cfg.pipeline.entries[0] else {
+        panic!("expected Stage entry");
+    };
+    assert_eq!(s.on_pass, OnPass::Exit);
+}
+
+#[test]
+fn on_fail_defaults_to_exit() {
+    let yaml = "stages:\n  - name: only\n    prompt: p.md\n";
+    let dir = capsule_dir_with_config(yaml);
+    let cfg: Config = resolve(dir.path(), no_cli()).unwrap();
+    let PipelineEntry::Stage(ref s) = cfg.pipeline.entries[0] else {
+        panic!("expected Stage entry");
+    };
+    assert_eq!(s.on_fail, OnFail::Exit);
+}
+
+// ── Validation error tests ────────────────────────────────────────────────────
+
+#[test]
+fn iterations_combined_with_stages_is_rejected() {
+    let yaml = "iterations: 5\nstages:\n  - name: foo\n";
+    let dir = capsule_dir_with_config(yaml);
+    let err = resolve(dir.path(), no_cli()).unwrap_err();
+    let chain: String = err
+        .chain()
+        .map(|e| e.to_string())
+        .collect::<Vec<_>>()
+        .join(": ");
+    assert!(
+        chain.contains("iterations") && chain.contains("stages"),
+        "error should mention both fields; got: {chain}"
+    );
+}
+
+#[test]
+fn unknown_stage_reference_in_on_fail_is_rejected() {
+    let yaml = "stages:\n  - name: foo\n    on_fail: nonexistent\n";
+    let dir = capsule_dir_with_config(yaml);
+    let err = resolve(dir.path(), no_cli()).unwrap_err();
+    let chain: String = err
+        .chain()
+        .map(|e| e.to_string())
+        .collect::<Vec<_>>()
+        .join(": ");
+    assert!(
+        chain.contains("nonexistent"),
+        "error should name the unknown stage; got: {chain}"
+    );
+}
+
+#[test]
+fn unknown_stage_reference_in_on_pass_is_rejected() {
+    let yaml = "stages:\n  - name: foo\n    on_pass: ghost\n";
+    let dir = capsule_dir_with_config(yaml);
+    let err = resolve(dir.path(), no_cli()).unwrap_err();
+    let chain: String = err
+        .chain()
+        .map(|e| e.to_string())
+        .collect::<Vec<_>>()
+        .join(": ");
+    assert!(
+        chain.contains("ghost"),
+        "error should name the unknown stage; got: {chain}"
+    );
+}
+
+#[test]
+fn loop_stage_can_reference_another_loop_stage_in_on_fail() {
+    let yaml = "\
+stages:
+  - loop:
+      stages:
+        - name: a
+          on_fail: b
+        - name: b
+";
+    let dir = capsule_dir_with_config(yaml);
+    assert!(resolve(dir.path(), no_cli()).is_ok());
+}
+
+#[test]
+fn multi_stage_model_and_verbose_parsed() {
+    let yaml = "stages:\n  - name: s\nmodel: claude-haiku-4-5\nverbose: true\n";
+    let dir = capsule_dir_with_config(yaml);
+    let cfg: Config = resolve(dir.path(), no_cli()).unwrap();
+    assert_eq!(cfg.model.as_deref(), Some("claude-haiku-4-5"));
+    assert!(cfg.verbose);
 }


### PR DESCRIPTION
Closes #59

## Summary
- Defines `PipelineConfig`, `PipelineEntry`, `LoopConfig`, `StageConfig`, `OnPass`, `OnFail` public types
- Extends `config::resolve` to parse both flat-form and multi-stage YAML, desugaring flat-form to a single-stage loop
- Validates: nested loops (structural rejection), `iterations:+stages:` combo, unknown stage name references in routing
- `MAX_PIPELINE_ITERATIONS_DEFAULT = 1000`
- All 13 existing config tests pass; 12 new tests added

## Test plan
- [ ] `cargo test --test config` — 25 tests pass
- [ ] `cargo clippy --tests -- -D warnings` — clean
- [ ] Flat-form configs unchanged in behavior