### PR TITLE
feat: --env flag for capsule run/resume with POSIX validation and persistence

### DIFF
--- a/DOMAIN.md
+++ b/DOMAIN.md
@@ -103,7 +103,7 @@ String passed via `capsule run --input "..."`, injected into the first stage's p
 _Avoid_: Argument, seed
 
 **Run environment**:
-User-supplied `KEY=VALUE` pairs passed via `--env` on `capsule run`, injected into every container invocation and hook script for the duration of the run. Distinct from pipeline input (prompt-only, first invocation only) and `.capsule/.env` (committed defaults). Written to a temp file and passed via `--env-file` so values never appear in process arguments.
+User-supplied `KEY=VALUE` pairs passed via `--env` on `capsule run`, injected into every container invocation and hook script for the duration of the run. Persisted in pipeline state on resumable exits so `capsule resume` restores them; `--env` on resume merges on top (last writer wins per key). Distinct from pipeline input (prompt-only, first invocation only) and `.capsule/.env` (committed defaults). Written to a temp file and passed via `--env-file` so values never appear in process arguments.
 _Avoid_: Run args, run parameters, heap
 
 **Note injection**:

--- a/README.md
+++ b/README.md
@@ -53,8 +53,14 @@ capsule run --iterations 1 --rebuild          # force-rebuild the Docker image
 capsule run --iterations 3 --verbose          # show unfiltered container output
 capsule run --model claude-opus-4-6 --iterations 2
 capsule run --capsule-dir path/to/.capsule    # use a non-default config directory
+capsule run --env PARENT=79 --iterations 3    # inject run-scoped parameters into containers and hooks
 capsule completion bash | source              # enable tab-completion in the current shell
 capsule update                                # download and install the latest release
+```
+
+```sh
+capsule resume                                # resume from last interrupted run
+capsule resume --env KEY=newvalue             # resume with env override (merges on top of persisted pairs)
 ```
 
 ## Config directory
@@ -104,7 +110,7 @@ The following environment variables are available inside `before-each.sh`:
 |---|---|
 | `CAPSULE_WORKSPACE` | Absolute path to the workspace inside the container (mirrors the host path) |
 
-Both hooks receive variables from `.capsule/.env`.
+Both hooks receive variables from `.capsule/.env`. Variables passed via `--env KEY=VALUE` on `capsule run` or `capsule resume` are also injected into both hooks, overriding same-named `.env` keys.
 
 ## Releasing
 

--- a/docs/adr/0006-persist-env-across-resume.md
+++ b/docs/adr/0006-persist-env-across-resume.md
@@ -1,0 +1,38 @@
+# Persist run environment across resume
+
+Run environment (`--env KEY=VALUE` pairs) is a property of the Run, not the CLI
+invocation — the glossary defines it as lasting "for the duration of the run,"
+and `capsule resume` continues the same Run. We persist `--env` pairs in
+`last-run.json` and auto-restore them on resume, overriding PRD #93's original
+"no `--env` on resume" stance.
+
+## Considered options
+
+**Do not persist; resume runs without env pairs** — the PRD #93 position.
+Avoids putting user-supplied values on disk beyond the run's lifetime. Rejected:
+resumed stages silently lose environment they may depend on, violating the
+glossary definition of Run environment. The "ambiguity" the PRD aimed to avoid
+is a design-time ambiguity, while the ambiguity it creates is a runtime
+correctness failure.
+
+**Warn on resume but don't restore** — store a count of original env pairs in
+`last-run.json` and print a warning. Rejected: makes the failure visible but
+doesn't fix it; the user still can't resume correctly without re-running from
+scratch.
+
+## Consequences
+
+- `pipeline_state` in `last-run.json` gains an `env` field (array of
+  `[key, value]` pairs). Because `pipeline_state` is only written on resumable
+  exits (`FailExit`, `CapHit`, errors), env pairs are never persisted after
+  successful runs. Existing files without the field default to `[]`.
+- `capsule resume` accepts `--env KEY=VALUE` for overrides. Merge semantic:
+  persisted pairs are the base, `--env` flags on resume override per-key
+  (last writer wins). No `--unset-env` mechanic; users can set a key to empty
+  or edit `last-run.json` directly.
+- Security posture is unchanged: `last-run.json` sits in `.capsule/`, same
+  trust boundary as `.capsule/.env` (same user, gitignored). Env values are
+  only on disk between a failed run and the next run.
+- Hook idempotency is an existing contract, unaffected by this change.
+  `before-all.sh` re-fires on resume with the restored (possibly overridden)
+  env pairs.

--- a/examples/ralph-loop/README.md
+++ b/examples/ralph-loop/README.md
@@ -36,6 +36,12 @@ capsule run --input "Add a health-check endpoint to the API"
 
 The implementer will pick up any open `AFK` issues. Use `--input` to inject context at the start of the first stage's prompt.
 
+For run-scoped parameters that persist across all stages and hooks (e.g. filtering issues by parent), use `--env`:
+
+```sh
+capsule run --env PARENT=79    # $PARENT is available in every container and hook script
+```
+
 ## Key concepts shown
 
 - **Ralph loop** — implementer iterates until the `AFK` queue is empty, using `done` to signal completion rather than `pass`

--- a/src/config.rs
+++ b/src/config.rs
@@ -108,6 +108,8 @@ pub struct CliOverrides {
     pub github: Option<GithubScope>,
     pub input: Option<String>,
     pub min_token_lifetime_minutes: Option<u32>,
+    /// KEY=VALUE pairs injected into every container and hook invocation for this run.
+    pub env: Vec<(String, String)>,
 }
 
 // ── Flat-form serde types ─────────────────────────────────────────────────────

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -192,8 +192,11 @@ pub struct RunConfig {
     pub verbose: bool,
     /// Path to the `.env` file to pass via `--env-file` (None → omitted).
     pub env_file: Option<PathBuf>,
+    /// Path to a temp env-file written from `--env KEY=VALUE` pairs.
+    /// Emitted after `env_file` so user overrides take precedence over `.capsule/.env`.
+    pub extra_env_file: Option<PathBuf>,
     /// Path to a temp env-file containing `GH_TOKEN=<token>` (None → no token injected).
-    /// Passed as a second `--env-file` so the token never appears in the process arg list.
+    /// Passed as a final `--env-file` so the token never appears in the process arg list.
     pub gh_token_env_file: Option<PathBuf>,
     /// Git author/committer name passed as `GIT_AUTHOR_NAME` and `GIT_COMMITTER_NAME`.
     pub git_author_name: String,
@@ -285,6 +288,10 @@ pub fn build_docker_args(
 
     if let Some(env_file) = &cfg.env_file {
         args.push(format!("--env-file={}", env_file.display()));
+    }
+
+    if let Some(extra_file) = &cfg.extra_env_file {
+        args.push(format!("--env-file={}", extra_file.display()));
     }
 
     if let Some(token_file) = &cfg.gh_token_env_file {
@@ -842,6 +849,53 @@ mod tests {
         assert!(
             joined.contains("gh-token.env"),
             "expected token file path in args: {joined}"
+        );
+    }
+
+    #[test]
+    fn extra_env_file_emitted_after_primary_env_file() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let primary = dir.path().join(".env");
+        let extra = dir.path().join("extra.env");
+        std::fs::write(&primary, "FOO=default\n").unwrap();
+        std::fs::write(&extra, "FOO=override\n").unwrap();
+        let prompt_file = tempfile::NamedTempFile::new().unwrap();
+        let cfg = RunConfig {
+            pwd: dir.path().to_path_buf(),
+            env_file: Some(primary.clone()),
+            extra_env_file: Some(extra.clone()),
+            ..RunConfig::default()
+        };
+        let args = build_docker_args(&cfg, prompt_file.path(), "capsule-test");
+        let primary_pos = args
+            .iter()
+            .position(|a| a.contains(".env") && !a.contains("extra"))
+            .expect("primary env-file not found");
+        let extra_pos = args
+            .iter()
+            .position(|a| a.contains("extra.env"))
+            .expect("extra env-file not found");
+        assert!(
+            primary_pos < extra_pos,
+            "primary .env must appear before extra.env (override ordering)"
+        );
+    }
+
+    #[test]
+    fn extra_env_file_absent_when_none() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let prompt_file = tempfile::NamedTempFile::new().unwrap();
+        let cfg = RunConfig {
+            pwd: dir.path().to_path_buf(),
+            ..RunConfig::default()
+        };
+        let args = build_docker_args(&cfg, prompt_file.path(), "capsule-test");
+        // Without extra_env_file only the primary --env-file (if any) may appear.
+        // Since env_file is also None here, no --env-file at all.
+        let joined = args.join(" ");
+        assert!(
+            !joined.contains("extra"),
+            "extra env-file must not appear when None: {joined}"
         );
     }
 

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -5,16 +5,22 @@ use std::process::Command;
 /// Run `${capsule_dir}/before-all.sh` on the host if it exists.
 ///
 /// The script runs with the current process environment (which includes any
-/// variables sourced from `${capsule_dir}/.env`). Non-zero exit aborts the
-/// entire run. Absent script → Ok(()).
-pub fn run_before_all(capsule_dir: &Path) -> Result<()> {
+/// variables sourced from `${capsule_dir}/.env`), plus `env_pairs` injected
+/// on top so `--env` values override same-named keys from `.env`.
+/// Non-zero exit aborts the entire run. Absent script → Ok(()).
+pub fn run_before_all(capsule_dir: &Path, env_pairs: &[(String, String)]) -> Result<()> {
     let script = capsule_dir.join("before-all.sh");
     if !script.exists() {
         return Ok(());
     }
 
-    let status = Command::new("bash")
-        .arg(&script)
+    let mut cmd = Command::new("bash");
+    cmd.arg(&script);
+    for (k, v) in env_pairs {
+        cmd.env(k, v);
+    }
+
+    let status = cmd
         .status()
         .with_context(|| format!("failed to run before-all.sh at {}", script.display()))?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -127,6 +127,15 @@ fn parse_env_pairs(raw: Vec<String>) -> Result<Vec<(String, String)>> {
         if k.starts_with("CAPSULE_") {
             anyhow::bail!("--env: key {k:?} is reserved — CAPSULE_* keys are owned by capsule");
         }
+        if !k.bytes().enumerate().all(|(i, b)| match b {
+            b'A'..=b'Z' | b'a'..=b'z' | b'_' => true,
+            b'0'..=b'9' if i > 0 => true,
+            _ => false,
+        }) {
+            anyhow::bail!(
+                "--env: key {k:?} is not a valid POSIX name — must match [A-Za-z_][A-Za-z0-9_]*"
+            );
+        }
         pairs.push((k.to_string(), v.to_string()));
     }
     Ok(pairs)
@@ -294,6 +303,39 @@ mod tests {
             err.to_string().contains("newline"),
             "error should mention newline: {err}"
         );
+    }
+
+    #[test]
+    fn parse_env_key_starting_with_digit_rejected() {
+        let err = parse_env_pairs(vec!["1FOO=bar".to_string()]).unwrap_err();
+        assert!(
+            err.to_string().contains("POSIX"),
+            "error should mention POSIX naming: {err}"
+        );
+    }
+
+    #[test]
+    fn parse_env_key_with_hash_rejected() {
+        let err = parse_env_pairs(vec!["#COMMENT=bar".to_string()]).unwrap_err();
+        assert!(
+            err.to_string().contains("POSIX"),
+            "error should mention POSIX naming: {err}"
+        );
+    }
+
+    #[test]
+    fn parse_env_key_with_space_rejected() {
+        let err = parse_env_pairs(vec!["MY KEY=bar".to_string()]).unwrap_err();
+        assert!(
+            err.to_string().contains("POSIX"),
+            "error should mention POSIX naming: {err}"
+        );
+    }
+
+    #[test]
+    fn parse_env_valid_key_with_underscores_and_digits() {
+        let pairs = parse_env_pairs(vec!["_MY_VAR_2=hello".to_string()]).unwrap();
+        assert_eq!(pairs, vec![("_MY_VAR_2".to_string(), "hello".to_string())]);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -83,6 +83,12 @@ enum Commands {
         /// Minimum remaining token lifetime (minutes) before prompting to refresh.
         #[arg(long)]
         min_token_lifetime_minutes: Option<u32>,
+
+        /// Inject KEY=VALUE into the container environment and hook scripts for this run.
+        /// Repeatable. Values override same-named keys in .capsule/.env.
+        /// CAPSULE_* keys are reserved and rejected.
+        #[arg(long = "env", value_name = "KEY=VALUE")]
+        env: Vec<String>,
     },
 
     /// Resume pipeline from the last interrupted run (reads last-run.json)
@@ -104,6 +110,26 @@ enum Commands {
     /// Run the MCP server over stdio (used inside the container by Claude Code)
     #[command(hide = true)]
     McpServe,
+}
+
+fn parse_env_pairs(raw: Vec<String>) -> Result<Vec<(String, String)>> {
+    let mut pairs = Vec::new();
+    for s in raw {
+        let Some((k, v)) = s.split_once('=') else {
+            anyhow::bail!("--env: invalid format {s:?} — expected KEY=VALUE");
+        };
+        if k.is_empty() {
+            anyhow::bail!("--env: key must not be empty in {s:?}");
+        }
+        if k.contains(['\n', '\r', '\0']) || v.contains(['\n', '\r', '\0']) {
+            anyhow::bail!("--env: key or value must not contain newline or null characters");
+        }
+        if k.starts_with("CAPSULE_") {
+            anyhow::bail!("--env: key {k:?} is reserved — CAPSULE_* keys are owned by capsule");
+        }
+        pairs.push((k.to_string(), v.to_string()));
+    }
+    Ok(pairs)
 }
 
 fn main() -> Result<()> {
@@ -158,6 +184,7 @@ fn main() -> Result<()> {
             github,
             input,
             min_token_lifetime_minutes,
+            env,
         } => {
             let git_identity = match git_identity {
                 CliGitIdentity::User => Some(GitIdentity::User),
@@ -167,6 +194,7 @@ fn main() -> Result<()> {
                 CliGithubScope::Local => GithubScope::Local,
                 CliGithubScope::Global => GithubScope::Global,
             });
+            let env = parse_env_pairs(env)?;
             let overrides = CliOverrides {
                 iterations,
                 prompt,
@@ -177,6 +205,7 @@ fn main() -> Result<()> {
                 github,
                 input,
                 min_token_lifetime_minutes,
+                env,
             };
             match RunSession::prepare(capsule_dir, overrides)?.execute()? {
                 run::ExitDecision::Success => {
@@ -189,5 +218,91 @@ fn main() -> Result<()> {
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_env_valid_key_value() {
+        let pairs = parse_env_pairs(vec!["FOO=bar".to_string()]).unwrap();
+        assert_eq!(pairs, vec![("FOO".to_string(), "bar".to_string())]);
+    }
+
+    #[test]
+    fn parse_env_value_with_equals() {
+        let pairs = parse_env_pairs(vec!["FOO=a=b".to_string()]).unwrap();
+        assert_eq!(pairs, vec![("FOO".to_string(), "a=b".to_string())]);
+    }
+
+    #[test]
+    fn parse_env_multiple_pairs() {
+        let pairs = parse_env_pairs(vec!["A=1".to_string(), "B=2".to_string()]).unwrap();
+        assert_eq!(pairs.len(), 2);
+        assert_eq!(pairs[0], ("A".to_string(), "1".to_string()));
+        assert_eq!(pairs[1], ("B".to_string(), "2".to_string()));
+    }
+
+    #[test]
+    fn parse_env_missing_equals_is_error() {
+        let err = parse_env_pairs(vec!["NOEQUALS".to_string()]).unwrap_err();
+        assert!(
+            err.to_string().contains("KEY=VALUE"),
+            "error should mention KEY=VALUE format: {err}"
+        );
+    }
+
+    #[test]
+    fn parse_env_capsule_prefix_rejected() {
+        let err = parse_env_pairs(vec!["CAPSULE_FOO=x".to_string()]).unwrap_err();
+        assert!(
+            err.to_string().contains("reserved"),
+            "error should mention reserved: {err}"
+        );
+    }
+
+    #[test]
+    fn parse_env_empty_vec_ok() {
+        let pairs = parse_env_pairs(vec![]).unwrap();
+        assert!(pairs.is_empty());
+    }
+
+    #[test]
+    fn parse_env_empty_key_rejected() {
+        let err = parse_env_pairs(vec!["=value".to_string()]).unwrap_err();
+        assert!(
+            err.to_string().contains("must not be empty"),
+            "error should mention empty key: {err}"
+        );
+    }
+
+    #[test]
+    fn parse_env_newline_in_value_rejected() {
+        let err = parse_env_pairs(vec!["KEY=val\nINJECT=bad".to_string()]).unwrap_err();
+        assert!(
+            err.to_string().contains("newline"),
+            "error should mention newline: {err}"
+        );
+    }
+
+    #[test]
+    fn parse_env_newline_in_key_rejected() {
+        let err = parse_env_pairs(vec!["KEY\nINJECT=val".to_string()]).unwrap_err();
+        assert!(
+            err.to_string().contains("newline"),
+            "error should mention newline: {err}"
+        );
+    }
+
+    #[test]
+    fn parse_env_capsule_bypass_via_newline_rejected() {
+        // Regression: newline in value must not let CAPSULE_* slip through.
+        let err = parse_env_pairs(vec!["TASK=foo\nCAPSULE_MODEL=evil".to_string()]).unwrap_err();
+        assert!(
+            err.to_string().contains("newline"),
+            "newline bypass of CAPSULE_* guard must be caught: {err}"
+        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -118,20 +118,19 @@ fn parse_env_pairs(raw: Vec<String>) -> Result<Vec<(String, String)>> {
         let Some((k, v)) = s.split_once('=') else {
             anyhow::bail!("--env: invalid format {s:?} — expected KEY=VALUE");
         };
-        if k.is_empty() {
-            anyhow::bail!("--env: key must not be empty in {s:?}");
-        }
         if k.contains(['\n', '\r', '\0']) || v.contains(['\n', '\r', '\0']) {
             anyhow::bail!("--env: key or value must not contain newline or null characters");
         }
         if k.starts_with("CAPSULE_") {
             anyhow::bail!("--env: key {k:?} is reserved — CAPSULE_* keys are owned by capsule");
         }
-        if !k.bytes().enumerate().all(|(i, b)| match b {
-            b'A'..=b'Z' | b'a'..=b'z' | b'_' => true,
-            b'0'..=b'9' if i > 0 => true,
-            _ => false,
-        }) {
+        if k.is_empty()
+            || !k.bytes().enumerate().all(|(i, b)| match b {
+                b'A'..=b'Z' | b'a'..=b'z' | b'_' => true,
+                b'0'..=b'9' if i > 0 => true,
+                _ => false,
+            })
+        {
             anyhow::bail!(
                 "--env: key {k:?} is not a valid POSIX name — must match [A-Za-z_][A-Za-z0-9_]*"
             );
@@ -282,8 +281,8 @@ mod tests {
     fn parse_env_empty_key_rejected() {
         let err = parse_env_pairs(vec!["=value".to_string()]).unwrap_err();
         assert!(
-            err.to_string().contains("must not be empty"),
-            "error should mention empty key: {err}"
+            err.to_string().contains("POSIX"),
+            "error should mention POSIX naming: {err}"
         );
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -96,6 +96,11 @@ enum Commands {
         /// Directory containing config, prompt, and hook scripts (default: ./.capsule)
         #[arg(long, default_value = ".capsule")]
         capsule_dir: PathBuf,
+
+        /// Override or add KEY=VALUE pairs on top of persisted run environment.
+        /// Repeatable. CLI values win per key. CAPSULE_* keys are reserved.
+        #[arg(long = "env", value_name = "KEY=VALUE")]
+        env: Vec<String>,
     },
 
     /// Print shell completion script to stdout
@@ -144,8 +149,9 @@ fn main() -> Result<()> {
     let cli = Cli::parse();
 
     match cli.command {
-        Commands::Resume { capsule_dir } => {
-            match RunSession::prepare_resume(capsule_dir)?.execute()? {
+        Commands::Resume { capsule_dir, env } => {
+            let env = parse_env_pairs(env)?;
+            match RunSession::prepare_resume(capsule_dir, env)?.execute()? {
                 run::ExitDecision::Success => {
                     println!("Claude submitted a pass verdict.");
                     Ok(())

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -59,6 +59,8 @@ pub struct PipelineState {
     pub last_stage: Option<String>,
     pub last_verdict: Option<crate::verdict::Verdict>,
     pub loop_iterations: HashMap<usize, u32>,
+    /// Run environment pairs persisted for resume; empty after successful exits.
+    pub env: Vec<(String, String)>,
 }
 
 /// Mutable progress tracked across stage invocations during a pipeline run.
@@ -228,6 +230,7 @@ impl<R: StageRunner> PipelineExecutor<R> {
             last_stage: progress.last_stage.clone(),
             last_verdict: progress.last_verdict.clone(),
             loop_iterations: loop_iterations.clone(),
+            env: vec![],
         };
 
         PipelineRunResult {

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -59,7 +59,7 @@ pub struct PipelineState {
     pub last_stage: Option<String>,
     pub last_verdict: Option<crate::verdict::Verdict>,
     pub loop_iterations: HashMap<usize, u32>,
-    /// Run environment pairs persisted for resume; empty after successful exits.
+    /// Run environment pairs persisted for resume; omitted from disk on successful exits.
     pub env: Vec<(String, String)>,
 }
 

--- a/src/run.rs
+++ b/src/run.rs
@@ -116,8 +116,9 @@ pub(crate) struct RunSession {
     env_file: Option<PathBuf>,
     before_each_path: Option<PathBuf>,
     compose_network: Option<String>,
-    // Held here so the temp file stays alive through execute().
+    // Held here so the temp files stay alive through execute().
     gh_token_tempfile: Option<tempfile::NamedTempFile>,
+    extra_env_tempfile: Option<tempfile::NamedTempFile>,
     credentials_guard: Option<CredentialsGuard>,
     active_container: Arc<Mutex<Option<String>>>,
     resume: Option<(String, PipelineState)>,
@@ -128,6 +129,7 @@ impl RunSession {
     /// detect infrastructure, register Ctrl-C handler.
     pub(crate) fn prepare(capsule_dir: PathBuf, mut overrides: CliOverrides) -> Result<Self> {
         let input = overrides.input.take();
+        let env_pairs: Vec<(String, String)> = std::mem::take(&mut overrides.env);
         let mut cfg = resolve(&capsule_dir, overrides)?;
 
         check_docker()?;
@@ -191,7 +193,9 @@ impl RunSession {
         let image = build_derived_image(&cfg.capsule_dir, &pwd, cfg.rebuild)?
             .unwrap_or_else(|| "capsule".to_string());
 
-        run_before_all(&cfg.capsule_dir)?;
+        run_before_all(&cfg.capsule_dir, &env_pairs)?;
+
+        let extra_env_tempfile = build_extra_env_tempfile(&env_pairs)?;
 
         let env_file_path = cfg.capsule_dir.join(".env");
         let env_file = if env_file_path.exists() {
@@ -236,6 +240,7 @@ impl RunSession {
             before_each_path,
             compose_network,
             gh_token_tempfile,
+            extra_env_tempfile,
             credentials_guard,
             active_container,
             resume: None,
@@ -340,6 +345,10 @@ impl RunSession {
             model: self.cfg.model.clone(),
             verbose: self.cfg.verbose,
             env_file: self.env_file.clone(),
+            extra_env_file: self
+                .extra_env_tempfile
+                .as_ref()
+                .map(|f| f.path().to_path_buf()),
             gh_token_env_file: self
                 .gh_token_tempfile
                 .as_ref()
@@ -500,6 +509,23 @@ impl DockerStageRunner {
         }
         result.verdict
     }
+}
+
+/// Write `--env` pairs to a `NamedTempFile` in dotenv format.
+/// Returns `None` when `pairs` is empty so no temp file is created.
+fn build_extra_env_tempfile(pairs: &[(String, String)]) -> Result<Option<tempfile::NamedTempFile>> {
+    if pairs.is_empty() {
+        return Ok(None);
+    }
+    let mut tmp = tempfile::Builder::new()
+        .prefix("capsule-env-")
+        .suffix(".env")
+        .tempfile()
+        .context("failed to create --env temp file")?;
+    for (k, v) in pairs {
+        writeln!(tmp, "{k}={v}").context("failed to write --env temp file")?;
+    }
+    Ok(Some(tmp))
 }
 
 fn resolve_stage_prompts(entries: &mut Vec<PipelineEntry>, capsule_dir: &Path) -> Result<()> {
@@ -1097,5 +1123,32 @@ mod tests {
         write_last_run(dir.path(), &s, Some(&state)).unwrap();
         let err = parse_resume_state(dir.path()).unwrap_err();
         assert!(err.to_string().contains("no session_id"), "err: {err}");
+    }
+
+    // ── build_extra_env_tempfile ──────────────────────────────────────────────
+
+    #[test]
+    fn extra_env_tempfile_empty_pairs_returns_none() {
+        let result = build_extra_env_tempfile(&[]).unwrap();
+        assert!(result.is_none(), "empty pairs must produce no tempfile");
+    }
+
+    #[test]
+    fn extra_env_tempfile_content_is_dotenv_format() {
+        let pairs = vec![
+            ("FOO".to_string(), "bar".to_string()),
+            ("BAZ".to_string(), "qux".to_string()),
+        ];
+        let tmp = build_extra_env_tempfile(&pairs).unwrap().unwrap();
+        let content = std::fs::read_to_string(tmp.path()).unwrap();
+        assert_eq!(content, "FOO=bar\nBAZ=qux\n");
+    }
+
+    #[test]
+    fn extra_env_tempfile_single_pair() {
+        let pairs = vec![("KEY".to_string(), "value".to_string())];
+        let tmp = build_extra_env_tempfile(&pairs).unwrap().unwrap();
+        let content = std::fs::read_to_string(tmp.path()).unwrap();
+        assert_eq!(content, "KEY=value\n");
     }
 }

--- a/src/run.rs
+++ b/src/run.rs
@@ -254,10 +254,14 @@ impl RunSession {
     ///
     /// Uses default CLI overrides — model, verbose, rebuild etc. come from
     /// `config.yml` only.  The `Resume` subcommand does not accept those flags.
-    pub(crate) fn prepare_resume(capsule_dir: PathBuf) -> Result<Self> {
+    pub(crate) fn prepare_resume(
+        capsule_dir: PathBuf,
+        cli_env: Vec<(String, String)>,
+    ) -> Result<Self> {
         let resume_data = parse_resume_state(&capsule_dir)?;
+        let merged_env = merge_env(&resume_data.1.env, &cli_env);
         let overrides = capsule::config::CliOverrides {
-            env: resume_data.1.env.clone(),
+            env: merged_env,
             ..Default::default()
         };
         let mut session = Self::prepare(capsule_dir, overrides)?;
@@ -516,6 +520,23 @@ impl DockerStageRunner {
         }
         result.verdict
     }
+}
+
+/// Merge persisted run-environment pairs with CLI overrides. Persisted pairs
+/// form the base; any same-key CLI pair overwrites; new CLI keys are appended.
+fn merge_env(
+    persisted: &[(String, String)],
+    cli_overrides: &[(String, String)],
+) -> Vec<(String, String)> {
+    let mut result: Vec<(String, String)> = persisted.to_vec();
+    for (k, v) in cli_overrides {
+        if let Some(existing) = result.iter_mut().find(|(ek, _)| ek == k) {
+            existing.1 = v.clone();
+        } else {
+            result.push((k.clone(), v.clone()));
+        }
+    }
+    result
 }
 
 /// Write `--env` pairs to a `NamedTempFile` in dotenv format.
@@ -1235,6 +1256,27 @@ mod tests {
         .unwrap();
         let (_, restored) = parse_resume_state(dir.path()).unwrap();
         assert_eq!(restored.env, vec![], "missing env field must default to []");
+    }
+
+    #[test]
+    fn merge_env_cli_overrides_persisted_per_key() {
+        let persisted = vec![
+            ("A".to_string(), "1".to_string()),
+            ("B".to_string(), "2".to_string()),
+        ];
+        let cli = vec![
+            ("B".to_string(), "3".to_string()),
+            ("C".to_string(), "4".to_string()),
+        ];
+        let merged = merge_env(&persisted, &cli);
+        assert_eq!(
+            merged,
+            vec![
+                ("A".to_string(), "1".to_string()),
+                ("B".to_string(), "3".to_string()),
+                ("C".to_string(), "4".to_string()),
+            ]
+        );
     }
 
     #[test]

--- a/src/run.rs
+++ b/src/run.rs
@@ -122,6 +122,7 @@ pub(crate) struct RunSession {
     credentials_guard: Option<CredentialsGuard>,
     active_container: Arc<Mutex<Option<String>>>,
     resume: Option<(String, PipelineState)>,
+    env_pairs: Vec<(String, String)>,
 }
 
 impl RunSession {
@@ -244,6 +245,7 @@ impl RunSession {
             credentials_guard,
             active_container,
             resume: None,
+            env_pairs,
         })
     }
 
@@ -254,7 +256,11 @@ impl RunSession {
     /// `config.yml` only.  The `Resume` subcommand does not accept those flags.
     pub(crate) fn prepare_resume(capsule_dir: PathBuf) -> Result<Self> {
         let resume_data = parse_resume_state(&capsule_dir)?;
-        let mut session = Self::prepare(capsule_dir, capsule::config::CliOverrides::default())?;
+        let overrides = capsule::config::CliOverrides {
+            env: resume_data.1.env.clone(),
+            ..Default::default()
+        };
+        let mut session = Self::prepare(capsule_dir, overrides)?;
         session.resume = Some(resume_data);
         Ok(session)
     }
@@ -381,6 +387,7 @@ impl RunSession {
                 .run()
         };
         result.summary.session_id = last_session_id.lock().unwrap().take();
+        result.pipeline_state.env = self.env_pairs.clone();
         if let Some(e) = last_error.lock().unwrap().take() {
             let _ = write_last_run(
                 &self.cfg.capsule_dir,
@@ -599,6 +606,11 @@ fn pipeline_state_to_json(state: &PipelineState) -> serde_json::Value {
         .last_verdict
         .as_ref()
         .map(|v| serde_json::to_value(v).unwrap_or(serde_json::Value::Null));
+    let env: Vec<serde_json::Value> = state
+        .env
+        .iter()
+        .map(|(k, v)| serde_json::json!([k, v]))
+        .collect();
     serde_json::json!({
         "current_idx": state.current_idx,
         "global_counter": state.global_counter,
@@ -606,6 +618,7 @@ fn pipeline_state_to_json(state: &PipelineState) -> serde_json::Value {
         "last_stage": state.last_stage,
         "last_verdict": last_verdict,
         "loop_iterations": loop_iterations,
+        "env": env,
     })
 }
 
@@ -667,6 +680,19 @@ fn parse_resume_state(capsule_dir: &Path) -> Result<(String, PipelineState)> {
         })
         .unwrap_or_default();
 
+    let env: Vec<(String, String)> = state_json["env"]
+        .as_array()
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|pair| {
+                    let k = pair[0].as_str()?.to_owned();
+                    let v = pair[1].as_str()?.to_owned();
+                    Some((k, v))
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+
     Ok((
         session_id,
         PipelineState {
@@ -676,6 +702,7 @@ fn parse_resume_state(capsule_dir: &Path) -> Result<(String, PipelineState)> {
             last_stage,
             last_verdict,
             loop_iterations,
+            env,
         },
     ))
 }
@@ -1044,6 +1071,7 @@ mod tests {
                 notes: Some("oops".to_string()),
             }),
             loop_iterations: loop_iters,
+            env: vec![],
         }
     }
 
@@ -1150,5 +1178,85 @@ mod tests {
         let tmp = build_extra_env_tempfile(&pairs).unwrap().unwrap();
         let content = std::fs::read_to_string(tmp.path()).unwrap();
         assert_eq!(content, "KEY=value\n");
+    }
+
+    // ── env persistence in pipeline_state ────────────────────────────────────
+
+    #[test]
+    fn parse_resume_state_round_trips_env_pairs() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut s = minimal_summary(TerminalReason::FailExit);
+        s.session_id = Some("sess_env".to_string());
+        let state = PipelineState {
+            current_idx: 0,
+            global_counter: 0,
+            fail_counts: HashMap::new(),
+            last_stage: None,
+            last_verdict: None,
+            loop_iterations: HashMap::new(),
+            env: vec![
+                ("PARENT".to_string(), "42".to_string()),
+                ("MODE".to_string(), "test".to_string()),
+            ],
+        };
+        write_last_run(dir.path(), &s, Some(&state)).unwrap();
+        let (_, restored) = parse_resume_state(dir.path()).unwrap();
+        assert_eq!(restored.env.len(), 2);
+        assert_eq!(restored.env[0], ("PARENT".to_string(), "42".to_string()));
+        assert_eq!(restored.env[1], ("MODE".to_string(), "test".to_string()));
+    }
+
+    #[test]
+    fn parse_resume_state_env_defaults_to_empty_when_field_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        // Write a last-run.json that has no "env" field in pipeline_state (old format).
+        let json = serde_json::json!({
+            "terminal_reason": "fail-exit",
+            "cap_hit_counter": null,
+            "last_stage": null,
+            "last_verdict": null,
+            "session_id": "sess_old",
+            "iteration_counters": { "global": 0, "loops": {} },
+            "pipeline_state": {
+                "current_idx": 1,
+                "global_counter": 2,
+                "fail_counts": {},
+                "last_stage": null,
+                "last_verdict": null,
+                "loop_iterations": {}
+            },
+            "timestamp": "2026-01-01T00:00:00Z",
+            "workspace_dirty": false
+        });
+        std::fs::write(
+            dir.path().join("last-run.json"),
+            serde_json::to_string_pretty(&json).unwrap(),
+        )
+        .unwrap();
+        let (_, restored) = parse_resume_state(dir.path()).unwrap();
+        assert_eq!(restored.env, vec![], "missing env field must default to []");
+    }
+
+    #[test]
+    fn pipeline_state_json_includes_env_pairs() {
+        let state = PipelineState {
+            current_idx: 0,
+            global_counter: 0,
+            fail_counts: HashMap::new(),
+            last_stage: None,
+            last_verdict: None,
+            loop_iterations: HashMap::new(),
+            env: vec![
+                ("PARENT".to_string(), "79".to_string()),
+                ("MODE".to_string(), "dry".to_string()),
+            ],
+        };
+        let json = pipeline_state_to_json(&state);
+        let env = json["env"].as_array().expect("env must be an array");
+        assert_eq!(env.len(), 2);
+        assert_eq!(env[0][0], "PARENT");
+        assert_eq!(env[0][1], "79");
+        assert_eq!(env[1][0], "MODE");
+        assert_eq!(env[1][1], "dry");
     }
 }

--- a/src/run.rs
+++ b/src/run.rs
@@ -252,8 +252,9 @@ impl RunSession {
     /// Read `last-run.json` from `capsule_dir`, extract saved state, then prepare
     /// the session identically to `prepare`. `execute()` will resume the pipeline.
     ///
-    /// Uses default CLI overrides — model, verbose, rebuild etc. come from
-    /// `config.yml` only.  The `Resume` subcommand does not accept those flags.
+    /// `cli_env` pairs are merged on top of the persisted run environment (CLI
+    /// wins per key). Model, verbose, rebuild, and other flags come from
+    /// `config.yml` only — `capsule resume` does not accept those overrides.
     pub(crate) fn prepare_resume(
         capsule_dir: PathBuf,
         cli_env: Vec<(String, String)>,
@@ -1256,6 +1257,29 @@ mod tests {
         .unwrap();
         let (_, restored) = parse_resume_state(dir.path()).unwrap();
         assert_eq!(restored.env, vec![], "missing env field must default to []");
+    }
+
+    #[test]
+    fn merge_env_both_empty_returns_empty() {
+        assert_eq!(merge_env(&[], &[]), vec![]);
+    }
+
+    #[test]
+    fn merge_env_no_persisted_returns_cli_pairs() {
+        let cli = vec![
+            ("A".to_string(), "1".to_string()),
+            ("B".to_string(), "2".to_string()),
+        ];
+        assert_eq!(merge_env(&[], &cli), cli);
+    }
+
+    #[test]
+    fn merge_env_no_cli_returns_persisted_unchanged() {
+        let persisted = vec![
+            ("A".to_string(), "1".to_string()),
+            ("B".to_string(), "2".to_string()),
+        ];
+        assert_eq!(merge_env(&persisted, &[]), persisted);
     }
 
     #[test]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -80,6 +80,25 @@ fn version_flag_long_prints_version() {
 }
 
 #[test]
+fn resume_env_bad_format_exits_nonzero() {
+    // No capsule_dir needed — parse validation fires before any file I/O.
+    cmd()
+        .args(["resume", "--env", "NOEQUALS"])
+        .assert()
+        .failure();
+}
+
+#[test]
+fn resume_help_lists_env_flag() {
+    let output = cmd().args(["resume", "--help"]).assert().success();
+    let stdout = String::from_utf8(output.get_output().stdout.clone()).unwrap();
+    assert!(
+        stdout.contains("--env"),
+        "resume --help should mention --env flag"
+    );
+}
+
+#[test]
 fn bare_capsule_prints_help() {
     let output = cmd().assert().failure();
     let stderr = String::from_utf8(output.get_output().stderr.clone()).unwrap();

--- a/tests/docker.rs
+++ b/tests/docker.rs
@@ -574,3 +574,86 @@ fn extra_env_file_visible_across_stages() {
         .args(["rmi", "-f", "capsule-test-extra-env"])
         .output();
 }
+
+/// Verify that resume --env merge semantics reach the container.
+/// Simulates: persisted env [MODE=dry, TASK=42] + CLI override [MODE=wet, REGION=us]
+/// → merged [MODE=wet, TASK=42, REGION=us] visible inside the container.
+#[test]
+#[requires_docker]
+#[serial(run_iteration)]
+fn resume_env_merge_visible_in_container() {
+    use capsule::docker::RunConfig;
+    use std::io::Write;
+
+    let workdir = tempfile::tempdir().expect("temp workdir");
+    let output_file = workdir.path().join("env_check.txt");
+
+    let dockerfile = "FROM busybox\n\
+        ENTRYPOINT [\"sh\", \"-c\", \
+        \"echo MODE=$MODE,TASK=$TASK,REGION=$REGION > \\\"$CAPSULE_WORKSPACE/env_check.txt\\\"; exit 0\"]\n";
+    let mut child = std::process::Command::new("docker")
+        .args(["build", "-t", "capsule-test-resume-env-merge", "-"])
+        .stdin(std::process::Stdio::piped())
+        .spawn()
+        .expect("docker build should spawn");
+    child
+        .stdin
+        .as_mut()
+        .unwrap()
+        .write_all(dockerfile.as_bytes())
+        .unwrap();
+    child.wait().expect("docker build should complete");
+
+    // Simulate what prepare_resume does: merge persisted pairs with CLI overrides,
+    // then write the merged result to a single extra env-file for the container.
+    let persisted = vec![
+        ("MODE".to_string(), "dry".to_string()),
+        ("TASK".to_string(), "42".to_string()),
+    ];
+    let cli_overrides = vec![
+        ("MODE".to_string(), "wet".to_string()),
+        ("REGION".to_string(), "us".to_string()),
+    ];
+    // Use the same merge function as prepare_resume (tested via unit test).
+    // Here we reproduce the result directly to keep this test self-contained.
+    let mut merged = persisted.clone();
+    for (k, v) in &cli_overrides {
+        if let Some(e) = merged.iter_mut().find(|(ek, _)| ek == k) {
+            e.1 = v.clone();
+        } else {
+            merged.push((k.clone(), v.clone()));
+        }
+    }
+    let mut extra_env_tmp = tempfile::Builder::new()
+        .prefix("capsule-env-")
+        .suffix(".env")
+        .tempfile()
+        .unwrap();
+    for (k, v) in &merged {
+        writeln!(extra_env_tmp, "{k}={v}").unwrap();
+    }
+
+    let cfg = RunConfig {
+        image: "capsule-test-resume-env-merge".to_string(),
+        prompt: "ignored".to_string(),
+        pwd: workdir.path().to_path_buf(),
+        extra_env_file: Some(extra_env_tmp.path().to_path_buf()),
+        claude_dir: std::env::temp_dir(),
+        ..RunConfig::default()
+    };
+    let active = Arc::new(Mutex::new(None));
+
+    let result = run_iteration(&cfg, 1, &active);
+    assert!(result.is_ok(), "container run should succeed: {:?}", result);
+
+    let output =
+        std::fs::read_to_string(&output_file).expect("container should have written env_check.txt");
+    assert!(
+        output.trim() == "MODE=wet,TASK=42,REGION=us",
+        "container must see merged env values; got: {output:?}"
+    );
+
+    let _ = std::process::Command::new("docker")
+        .args(["rmi", "-f", "capsule-test-resume-env-merge"])
+        .output();
+}

--- a/tests/docker.rs
+++ b/tests/docker.rs
@@ -575,13 +575,13 @@ fn extra_env_file_visible_across_stages() {
         .output();
 }
 
-/// Verify that resume --env merge semantics reach the container.
-/// Simulates: persisted env [MODE=dry, TASK=42] + CLI override [MODE=wet, REGION=us]
-/// → merged [MODE=wet, TASK=42, REGION=us] visible inside the container.
+/// Verify that a pre-merged extra_env_file delivers all three expected values to the container.
+/// Constructs the merged env ([MODE=wet, TASK=42, REGION=us]) inline and confirms the container
+/// sees it via extra_env_file. The merge algorithm itself is tested by unit tests in src/run.rs.
 #[test]
 #[requires_docker]
 #[serial(run_iteration)]
-fn resume_env_merge_visible_in_container() {
+fn extra_env_file_delivers_merged_env_to_container() {
     use capsule::docker::RunConfig;
     use std::io::Write;
 
@@ -614,8 +614,7 @@ fn resume_env_merge_visible_in_container() {
         ("MODE".to_string(), "wet".to_string()),
         ("REGION".to_string(), "us".to_string()),
     ];
-    // Use the same merge function as prepare_resume (tested via unit test).
-    // Here we reproduce the result directly to keep this test self-contained.
+    // Inline the expected merged result; merge logic correctness is covered by unit tests.
     let mut merged = persisted.clone();
     for (k, v) in &cli_overrides {
         if let Some(e) = merged.iter_mut().find(|(ek, _)| ek == k) {

--- a/tests/docker.rs
+++ b/tests/docker.rs
@@ -498,3 +498,79 @@ fn entrypoint_uses_resume_when_env_set() {
         .args(["rmi", "-f", "capsule-resume-test"])
         .output();
 }
+
+/// Verify that extra_env_file values are visible in every container invocation.
+/// Two simulated "stages" (consecutive run_iteration calls) must both see the
+/// env var injected via extra_env_file, confirming persistence across stages.
+#[test]
+#[requires_docker]
+#[serial(run_iteration)]
+fn extra_env_file_visible_across_stages() {
+    let workdir = tempfile::tempdir().expect("temp workdir");
+
+    // Build a minimal image whose entrypoint writes the env var value to a file.
+    let dockerfile =
+        "FROM busybox\nENTRYPOINT [\"sh\", \"-c\", \"echo \\\"$MY_RUN_PARAM\\\" >> \\\"$CAPSULE_WORKSPACE/stage_outputs.txt\\\"; exit 0\"]\n";
+    let mut child = std::process::Command::new("docker")
+        .args(["build", "-t", "capsule-test-extra-env", "-"])
+        .stdin(std::process::Stdio::piped())
+        .spawn()
+        .expect("docker build should spawn");
+    {
+        child
+            .stdin
+            .as_mut()
+            .unwrap()
+            .write_all(dockerfile.as_bytes())
+            .unwrap();
+    }
+    child.wait().expect("docker build should complete");
+
+    // Write the --env pairs to a temp env-file (as RunSession does).
+    let mut extra_env_tmp = tempfile::Builder::new()
+        .prefix("capsule-env-")
+        .suffix(".env")
+        .tempfile()
+        .unwrap();
+    writeln!(extra_env_tmp, "MY_RUN_PARAM=expected_value").unwrap();
+
+    let cfg = RunConfig {
+        image: "capsule-test-extra-env".to_string(),
+        prompt: "ignored".to_string(),
+        pwd: workdir.path().to_path_buf(),
+        extra_env_file: Some(extra_env_tmp.path().to_path_buf()),
+        claude_dir: std::env::temp_dir(),
+        ..RunConfig::default()
+    };
+    let active = Arc::new(Mutex::new(None));
+
+    // Stage 1
+    let r1 = run_iteration(&cfg, 1, &active);
+    assert!(r1.is_ok(), "stage 1 should not error: {:?}", r1);
+
+    // Stage 2
+    let r2 = run_iteration(&cfg, 2, &active);
+    assert!(r2.is_ok(), "stage 2 should not error: {:?}", r2);
+
+    let outputs = std::fs::read_to_string(workdir.path().join("stage_outputs.txt"))
+        .expect("container should have written stage_outputs.txt");
+
+    let lines: Vec<&str> = outputs.lines().collect();
+    assert_eq!(
+        lines.len(),
+        2,
+        "both stages must have written output; got: {outputs:?}"
+    );
+    for (i, line) in lines.iter().enumerate() {
+        assert_eq!(
+            *line,
+            "expected_value",
+            "stage {} must see MY_RUN_PARAM=expected_value; got: {line:?}",
+            i + 1
+        );
+    }
+
+    let _ = std::process::Command::new("docker")
+        .args(["rmi", "-f", "capsule-test-extra-env"])
+        .output();
+}

--- a/tests/hooks.rs
+++ b/tests/hooks.rs
@@ -5,7 +5,7 @@ use std::os::unix::fs::PermissionsExt;
 #[test]
 fn before_all_absent_is_ok() {
     let dir = tempfile::tempdir().expect("temp dir");
-    let result = run_before_all(dir.path());
+    let result = run_before_all(dir.path(), &[]);
     assert!(
         result.is_ok(),
         "absent before-all.sh must return Ok: {result:?}"
@@ -19,7 +19,7 @@ fn before_all_success_is_ok() {
     fs::write(&script, "#!/bin/sh\nexit 0\n").unwrap();
     fs::set_permissions(&script, fs::Permissions::from_mode(0o755)).unwrap();
 
-    let result = run_before_all(dir.path());
+    let result = run_before_all(dir.path(), &[]);
     assert!(
         result.is_ok(),
         "before-all.sh exit 0 must return Ok: {result:?}"
@@ -33,7 +33,7 @@ fn before_all_failure_is_err() {
     fs::write(&script, "#!/bin/sh\nexit 42\n").unwrap();
     fs::set_permissions(&script, fs::Permissions::from_mode(0o755)).unwrap();
 
-    let result = run_before_all(dir.path());
+    let result = run_before_all(dir.path(), &[]);
     assert!(result.is_err(), "before-all.sh exit 42 must return Err");
     let msg = format!("{:?}", result.unwrap_err());
     assert!(
@@ -52,9 +52,29 @@ fn before_all_runs_on_host() {
     fs::write(&script, script_body).unwrap();
     fs::set_permissions(&script, fs::Permissions::from_mode(0o755)).unwrap();
 
-    run_before_all(dir.path()).expect("should succeed");
+    run_before_all(dir.path(), &[]).expect("should succeed");
     assert!(
         sentinel.exists(),
         "before-all.sh should have created sentinel file"
+    );
+}
+
+#[test]
+fn before_all_env_pairs_injected() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    let script = dir.path().join("before-all.sh");
+    let out_file = dir.path().join("env_value.txt");
+    let out_str = out_file.to_string_lossy();
+    let script_body = format!("#!/bin/sh\necho \"$MY_TEST_VAR\" > {out_str}\n");
+    fs::write(&script, script_body).unwrap();
+    fs::set_permissions(&script, fs::Permissions::from_mode(0o755)).unwrap();
+
+    let pairs = vec![("MY_TEST_VAR".to_string(), "hello_env".to_string())];
+    run_before_all(dir.path(), &pairs).expect("should succeed");
+
+    let content = fs::read_to_string(&out_file).expect("output file should exist");
+    assert!(
+        content.trim() == "hello_env",
+        "env var should be injected into hook: got {content:?}"
     );
 }


### PR DESCRIPTION
## Summary

- Adds `--env KEY=VALUE` flag to `capsule run` and `capsule resume` for injecting environment variables into containers
- Validates env keys against POSIX naming rules (non-empty, starts with letter/underscore, alphanumeric/underscore only)
- Persists the run environment in `pipeline_state` so `capsule resume` can merge/override with new `--env` values

## Commits

- `feat: add --env KEY=VALUE flag to capsule run (#94–#98)`
- `docs: ADR-0006 persist run environment across resume`
- `feat: validate --env keys against POSIX naming rules (#99)`
- `feat: persist run environment in pipeline_state for resume (#100)`
- `feat: accept --env on capsule resume with merge semantics (#101)`

## Test plan

- [ ] `cargo test` passes (unit + integration)
- [ ] Docker tests pass with a live daemon (`#[requires_docker]` tests)
- [ ] `capsule run --env KEY=VALUE` injects variable into container
- [ ] Invalid key (e.g. `1BAD=val`, `=val`) is rejected with a clear error
- [ ] `capsule resume --env NEW=val` merges with persisted env, new values win
- [ ] `capsule resume` without `--env` replays original env unchanged