### PR TITLE
feat: richer stream data extraction and context window usage

### DIFF
--- a/docs/adr/0007-claude-code-style-streaming-output.md
+++ b/docs/adr/0007-claude-code-style-streaming-output.md
@@ -13,4 +13,4 @@ Capsule's terminal output uses raw `println!`/`eprintln!` with no color or struc
 - `crossterm` added as a dependency (colors + cursor control).
 - `StreamParser` extended to extract tool-call results (success/failure), not just verdicts.
 - `entrypoint.sh` loud hook echo lines removed; proper hook rendering deferred to a future Docker-crate migration.
-- Context window usage display deferred to a later iteration.
+- Context window usage display added: live token count in the status panel info row during streaming, plus end-of-run context window percentage. _(Done — #189, #190, #191.)_

--- a/src/container_execution/mod.rs
+++ b/src/container_execution/mod.rs
@@ -10,7 +10,10 @@ pub use infra::{
 };
 pub use process::{post_stream_error, run_container, run_iteration, StreamResult};
 pub use runner::{CredentialsGuard, DockerStageRunner};
-pub use stream_parser::{StreamParser, ToolEvent, ToolResultEvent, ToolUseEvent};
+pub use stream_parser::{
+    format_usage_with_percentage, ModelUsage, StreamParser, ToolEvent, ToolResultEvent,
+    ToolUseEvent,
+};
 
 use std::path::PathBuf;
 
@@ -59,11 +62,15 @@ pub struct ExecutionConfig {
 #[derive(Debug)]
 pub enum IterationOutcome {
     /// Loop should continue to the next iteration.
-    Continue { session_id: Option<String> },
+    Continue {
+        session_id: Option<String>,
+        model_usage: Option<ModelUsage>,
+    },
     /// Claude submitted a verdict; loop should stop.
     Done {
         verdict: crate::verdict::Verdict,
         session_id: Option<String>,
+        model_usage: Option<ModelUsage>,
     },
     /// Auth failed but the host token is still valid; caller should re-copy
     /// credentials, call `CredentialsGuard::reset_baseline`, and retry with

--- a/src/container_execution/process.rs
+++ b/src/container_execution/process.rs
@@ -75,6 +75,9 @@ fn stream_output(reader: BufReader<impl std::io::Read>, verbose: bool) -> Result
             };
             crate::display::agent_text(text);
         }
+        if let Some(snap) = parser.last_usage_snapshot() {
+            crate::display::set_usage(snap.total_tokens());
+        }
         if !had_text
             && !had_tool_events
             && !verdict_seen

--- a/src/container_execution/process.rs
+++ b/src/container_execution/process.rs
@@ -1,6 +1,6 @@
 use super::docker_args::{build_docker_args, container_name_for};
 use super::infra::{host_token_is_expired, make_mcp_config};
-use super::stream_parser::{StreamParser, TextDisplay, ToolEvent};
+use super::stream_parser::{ModelUsage, StreamParser, TextDisplay, ToolEvent};
 use super::{ExecutionConfig, IterationOutcome};
 use anyhow::{Context, Result};
 use std::io::{BufRead, BufReader, Write};
@@ -12,6 +12,7 @@ pub struct StreamResult {
     pub submit_verdict_missing: bool,
     pub verdict: Option<crate::verdict::Verdict>,
     pub session_id: Option<String>,
+    pub model_usage: Option<ModelUsage>,
 }
 
 pub fn post_stream_error(
@@ -93,6 +94,7 @@ fn stream_output(reader: BufReader<impl std::io::Read>, verbose: bool) -> Result
         submit_verdict_missing: parser.submit_verdict_missing(),
         verdict: parser.verdict().cloned(),
         session_id: parser.session_id().map(str::to_owned),
+        model_usage: parser.model_usage().cloned(),
     })
 }
 
@@ -257,9 +259,11 @@ pub fn run_iteration(
         Some(verdict) => Ok(IterationOutcome::Done {
             verdict,
             session_id: result.session_id,
+            model_usage: result.model_usage,
         }),
         None => Ok(IterationOutcome::Continue {
             session_id: result.session_id,
+            model_usage: result.model_usage,
         }),
     }
 }
@@ -286,6 +290,7 @@ mod tests {
             submit_verdict_missing: false,
             verdict: None,
             session_id: None,
+            model_usage: None,
         }
     }
 

--- a/src/container_execution/runner.rs
+++ b/src/container_execution/runner.rs
@@ -9,7 +9,7 @@ use crate::verdict::Verdict;
 
 use super::{
     container_name_for, post_stream_error, run_container, run_iteration, ExecutionConfig,
-    IterationOutcome,
+    IterationOutcome, ModelUsage,
 };
 
 pub struct CredentialsGuard {
@@ -96,6 +96,7 @@ pub struct DockerStageRunner {
     active_container: Arc<Mutex<Option<String>>>,
     iteration: u32,
     session_id: Option<String>,
+    model_usage: Option<ModelUsage>,
     credentials_guard: Option<CredentialsGuard>,
     resume_session_id: Option<String>,
 }
@@ -112,6 +113,7 @@ impl DockerStageRunner {
             active_container,
             iteration: 0,
             session_id: None,
+            model_usage: None,
             credentials_guard,
             resume_session_id,
         }
@@ -119,6 +121,10 @@ impl DockerStageRunner {
 
     pub fn session_id(&self) -> Option<&str> {
         self.session_id.as_deref()
+    }
+
+    pub fn model_usage(&self) -> Option<&ModelUsage> {
+        self.model_usage.as_ref()
     }
 }
 
@@ -188,21 +194,34 @@ impl DockerStageRunner {
             if let Some(id) = result.session_id {
                 self.session_id = Some(id);
             }
+            if let Some(u) = result.model_usage {
+                self.model_usage = Some(u);
+            }
             return Ok(result.verdict);
         }
         match run_iteration(&cfg, self.iteration, &self.active_container)? {
             IterationOutcome::Done {
                 verdict,
                 session_id,
+                model_usage,
             } => {
                 if let Some(id) = session_id {
                     self.session_id = Some(id);
                 }
+                if let Some(u) = model_usage {
+                    self.model_usage = Some(u);
+                }
                 Ok(Some(verdict))
             }
-            IterationOutcome::Continue { session_id } => {
+            IterationOutcome::Continue {
+                session_id,
+                model_usage,
+            } => {
                 if let Some(id) = session_id {
                     self.session_id = Some(id);
+                }
+                if let Some(u) = model_usage {
+                    self.model_usage = Some(u);
                 }
                 Ok(None)
             }
@@ -238,6 +257,9 @@ impl DockerStageRunner {
         }
         if let Some(id) = result.session_id {
             self.session_id = Some(id);
+        }
+        if let Some(u) = result.model_usage {
+            self.model_usage = Some(u);
         }
         Ok(result.verdict)
     }

--- a/src/container_execution/stream_parser.rs
+++ b/src/container_execution/stream_parser.rs
@@ -23,6 +23,22 @@ pub enum TextDisplay {
     Thinking(String),
 }
 
+pub struct UsageSnapshot {
+    pub input_tokens: u64,
+    pub cache_creation_input_tokens: u64,
+    pub cache_read_input_tokens: u64,
+    pub output_tokens: u64,
+}
+
+impl UsageSnapshot {
+    pub fn total_tokens(&self) -> u64 {
+        self.input_tokens
+            + self.cache_creation_input_tokens
+            + self.cache_read_input_tokens
+            + self.output_tokens
+    }
+}
+
 pub struct StreamParser {
     verdict: Option<Verdict>,
     auth_failed: bool,
@@ -32,6 +48,7 @@ pub struct StreamParser {
     last_tool_events: Vec<ToolEvent>,
     last_text_displays: Vec<TextDisplay>,
     last_parsed_value: Option<Value>,
+    last_usage_snapshot: Option<UsageSnapshot>,
 }
 
 impl StreamParser {
@@ -45,6 +62,7 @@ impl StreamParser {
             last_tool_events: Vec::new(),
             last_text_displays: Vec::new(),
             last_parsed_value: None,
+            last_usage_snapshot: None,
         }
     }
 
@@ -52,6 +70,7 @@ impl StreamParser {
         self.last_tool_events.clear();
         self.last_text_displays.clear();
         self.last_parsed_value = None;
+        self.last_usage_snapshot = None;
         let Ok(msg) = serde_json::from_str::<Value>(line) else {
             return self.verdict.as_ref();
         };
@@ -77,6 +96,7 @@ impl StreamParser {
         let (tool_events, text_displays) = extract_assistant_content(&msg);
         self.last_tool_events = tool_events;
         self.last_text_displays = text_displays;
+        self.last_usage_snapshot = extract_usage_snapshot(&msg);
         if msg.get("type").is_some() {
             self.last_parsed_value = Some(msg);
         }
@@ -114,6 +134,12 @@ impl StreamParser {
     /// was valid JSON containing a `"type"` field.
     pub fn last_parsed_value(&self) -> Option<&Value> {
         self.last_parsed_value.as_ref()
+    }
+
+    /// Returns the usage snapshot extracted from the most recent `feed()` call, if the
+    /// line was an assistant message carrying `message.usage`.
+    pub fn last_usage_snapshot(&self) -> Option<&UsageSnapshot> {
+        self.last_usage_snapshot.as_ref()
     }
 }
 
@@ -223,6 +249,20 @@ fn extract_assistant_content(msg: &Value) -> (Vec<ToolEvent>, Vec<TextDisplay>) 
         }
         _ => (Vec::new(), Vec::new()),
     }
+}
+
+fn extract_usage_snapshot(msg: &Value) -> Option<UsageSnapshot> {
+    if msg.get("type").and_then(Value::as_str) != Some("assistant") {
+        return None;
+    }
+    let usage = msg.pointer("/message/usage")?;
+    let get_u64 = |key: &str| -> u64 { usage.get(key).and_then(Value::as_u64).unwrap_or(0) };
+    Some(UsageSnapshot {
+        input_tokens: get_u64("input_tokens"),
+        cache_creation_input_tokens: get_u64("cache_creation_input_tokens"),
+        cache_read_input_tokens: get_u64("cache_read_input_tokens"),
+        output_tokens: get_u64("output_tokens"),
+    })
 }
 
 fn extract_verdict(msg: &Value) -> Option<Verdict> {
@@ -793,5 +833,64 @@ mod tests {
     fn no_text_displays_before_any_feed() {
         let p = StreamParser::new();
         assert!(p.last_text_displays().is_empty());
+    }
+
+    const ASSISTANT_WITH_USAGE: &str = r#"{"type":"assistant","message":{"content":[{"type":"text","text":"hi"}],"usage":{"input_tokens":9,"cache_creation_input_tokens":32784,"cache_read_input_tokens":100,"output_tokens":8,"service_tier":"standard"}}}"#;
+    const ASSISTANT_WITHOUT_USAGE: &str =
+        r#"{"type":"assistant","message":{"content":[{"type":"text","text":"hi"}]}}"#;
+
+    #[test]
+    fn assistant_with_usage_yields_snapshot() {
+        let mut p = StreamParser::new();
+        p.feed(ASSISTANT_WITH_USAGE);
+        let snap = p.last_usage_snapshot().expect("expected usage snapshot");
+        assert_eq!(snap.input_tokens, 9);
+        assert_eq!(snap.cache_creation_input_tokens, 32784);
+        assert_eq!(snap.cache_read_input_tokens, 100);
+        assert_eq!(snap.output_tokens, 8);
+    }
+
+    #[test]
+    fn usage_snapshot_total_tokens_sums_all_fields() {
+        let mut p = StreamParser::new();
+        p.feed(ASSISTANT_WITH_USAGE);
+        let snap = p.last_usage_snapshot().expect("expected usage snapshot");
+        assert_eq!(snap.total_tokens(), 9 + 32784 + 100 + 8);
+    }
+
+    #[test]
+    fn assistant_without_usage_yields_no_snapshot() {
+        let mut p = StreamParser::new();
+        p.feed(ASSISTANT_WITHOUT_USAGE);
+        assert!(p.last_usage_snapshot().is_none());
+    }
+
+    #[test]
+    fn non_assistant_message_yields_no_snapshot() {
+        let mut p = StreamParser::new();
+        p.feed(RESULT_LINE);
+        assert!(p.last_usage_snapshot().is_none());
+    }
+
+    #[test]
+    fn missing_optional_cache_fields_default_to_zero() {
+        let line = r#"{"type":"assistant","message":{"content":[],"usage":{"input_tokens":5,"output_tokens":3}}}"#;
+        let mut p = StreamParser::new();
+        p.feed(line);
+        let snap = p.last_usage_snapshot().expect("expected usage snapshot");
+        assert_eq!(snap.input_tokens, 5);
+        assert_eq!(snap.cache_creation_input_tokens, 0);
+        assert_eq!(snap.cache_read_input_tokens, 0);
+        assert_eq!(snap.output_tokens, 3);
+        assert_eq!(snap.total_tokens(), 8);
+    }
+
+    #[test]
+    fn usage_snapshot_cleared_between_feeds() {
+        let mut p = StreamParser::new();
+        p.feed(ASSISTANT_WITH_USAGE);
+        assert!(p.last_usage_snapshot().is_some());
+        p.feed(ASSISTANT_WITHOUT_USAGE);
+        assert!(p.last_usage_snapshot().is_none());
     }
 }

--- a/src/container_execution/stream_parser.rs
+++ b/src/container_execution/stream_parser.rs
@@ -10,6 +10,7 @@ pub struct ToolUseEvent {
 pub struct ToolResultEvent {
     pub tool_use_id: String,
     pub is_error: bool,
+    pub content: Option<String>,
 }
 
 pub enum ToolEvent {
@@ -207,9 +208,14 @@ fn extract_assistant_content(msg: &Value) -> (Vec<ToolEvent>, Vec<TextDisplay>) 
                         .get("is_error")
                         .and_then(Value::as_bool)
                         .unwrap_or(false);
+                    let content = block
+                        .get("content")
+                        .and_then(Value::as_str)
+                        .map(str::to_owned);
                     Some(ToolEvent::Result(ToolResultEvent {
                         tool_use_id,
                         is_error,
+                        content,
                     }))
                 })
                 .collect();
@@ -584,6 +590,10 @@ mod tests {
         };
         assert_eq!(result_event.tool_use_id, "toolu_bash01");
         assert!(!result_event.is_error);
+        assert_eq!(
+            result_event.content.as_deref(),
+            Some("file1.txt\nfile2.txt")
+        );
     }
 
     #[test]
@@ -597,6 +607,21 @@ mod tests {
         };
         assert_eq!(result_event.tool_use_id, "toolu_bash01");
         assert!(result_event.is_error);
+        assert_eq!(result_event.content.as_deref(), Some("command not found"));
+    }
+
+    #[test]
+    fn tool_result_with_no_content_field_yields_none() {
+        let line = r#"{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"toolu_bash01","is_error":false}]}}"#;
+        let mut p = StreamParser::new();
+        p.feed(line);
+        let events = p.last_tool_events();
+        assert_eq!(events.len(), 1);
+        let ToolEvent::Result(result_event) = &events[0] else {
+            panic!("expected ToolEvent::Result");
+        };
+        assert_eq!(result_event.tool_use_id, "toolu_bash01");
+        assert!(result_event.content.is_none());
     }
 
     #[test]

--- a/src/container_execution/stream_parser.rs
+++ b/src/container_execution/stream_parser.rs
@@ -30,6 +30,25 @@ pub struct UsageSnapshot {
     pub output_tokens: u64,
 }
 
+#[derive(Debug, Clone)]
+pub struct ModelUsage {
+    pub context_window: u64,
+    pub input_tokens: u64,
+    pub output_tokens: u64,
+    pub cost_usd: f64,
+}
+
+/// Format total token usage with context window percentage, e.g. `"33.3k (16.6%) used"`.
+pub fn format_usage_with_percentage(total_tokens: u64, context_window: u64) -> String {
+    let k = total_tokens as f64 / 1000.0;
+    let pct = if context_window > 0 {
+        total_tokens as f64 / context_window as f64 * 100.0
+    } else {
+        0.0
+    };
+    format!("{k:.1}k ({pct:.1}%) used")
+}
+
 impl UsageSnapshot {
     pub fn total_tokens(&self) -> u64 {
         self.input_tokens
@@ -49,6 +68,7 @@ pub struct StreamParser {
     last_text_displays: Vec<TextDisplay>,
     last_parsed_value: Option<Value>,
     last_usage_snapshot: Option<UsageSnapshot>,
+    model_usage: Option<ModelUsage>,
 }
 
 impl StreamParser {
@@ -63,6 +83,7 @@ impl StreamParser {
             last_text_displays: Vec::new(),
             last_parsed_value: None,
             last_usage_snapshot: None,
+            model_usage: None,
         }
     }
 
@@ -97,6 +118,9 @@ impl StreamParser {
         self.last_tool_events = tool_events;
         self.last_text_displays = text_displays;
         self.last_usage_snapshot = extract_usage_snapshot(&msg);
+        if let Some(usage) = extract_model_usage(&msg) {
+            self.model_usage = Some(usage);
+        }
         if msg.get("type").is_some() {
             self.last_parsed_value = Some(msg);
         }
@@ -140,6 +164,11 @@ impl StreamParser {
     /// line was an assistant message carrying `message.usage`.
     pub fn last_usage_snapshot(&self) -> Option<&UsageSnapshot> {
         self.last_usage_snapshot.as_ref()
+    }
+
+    /// Returns model usage extracted from the final `"type": "result"` message, if seen.
+    pub fn model_usage(&self) -> Option<&ModelUsage> {
+        self.model_usage.as_ref()
     }
 }
 
@@ -263,6 +292,28 @@ fn extract_usage_snapshot(msg: &Value) -> Option<UsageSnapshot> {
         cache_read_input_tokens: get_u64("cache_read_input_tokens"),
         output_tokens: get_u64("output_tokens"),
     })
+}
+
+fn extract_model_usage(msg: &Value) -> Option<ModelUsage> {
+    if msg.get("type").and_then(Value::as_str) != Some("result") {
+        return None;
+    }
+    let model_usage_map = msg.get("modelUsage")?.as_object()?;
+    model_usage_map
+        .values()
+        .filter_map(|v| {
+            let context_window = v.get("contextWindow")?.as_u64()?;
+            let input_tokens = v.get("inputTokens").and_then(Value::as_u64).unwrap_or(0);
+            let output_tokens = v.get("outputTokens").and_then(Value::as_u64).unwrap_or(0);
+            let cost_usd = v.get("costUSD").and_then(Value::as_f64).unwrap_or(0.0);
+            Some(ModelUsage {
+                context_window,
+                input_tokens,
+                output_tokens,
+                cost_usd,
+            })
+        })
+        .max_by_key(|u| u.context_window)
 }
 
 fn extract_verdict(msg: &Value) -> Option<Verdict> {
@@ -892,5 +943,82 @@ mod tests {
         assert!(p.last_usage_snapshot().is_some());
         p.feed(ASSISTANT_WITHOUT_USAGE);
         assert!(p.last_usage_snapshot().is_none());
+    }
+
+    const RESULT_WITH_MODEL_USAGE: &str = r#"{"type":"result","subtype":"success","result":"done","modelUsage":{"claude-haiku-4-5-20251001":{"contextWindow":200000,"maxOutputTokens":32000,"inputTokens":388,"outputTokens":163,"costUSD":0.017286}}}"#;
+    const RESULT_MULTI_MODEL: &str = r#"{"type":"result","subtype":"success","result":"done","modelUsage":{"claude-haiku-4-5-20251001":{"contextWindow":200000,"inputTokens":100,"outputTokens":50,"costUSD":0.01},"claude-opus-4-7":{"contextWindow":1000000,"inputTokens":200,"outputTokens":80,"costUSD":0.05}}}"#;
+
+    #[test]
+    fn result_with_model_usage_extracts_correctly() {
+        let mut p = StreamParser::new();
+        p.feed(RESULT_WITH_MODEL_USAGE);
+        let usage = p.model_usage().expect("expected model usage");
+        assert_eq!(usage.context_window, 200000);
+        assert_eq!(usage.input_tokens, 388);
+        assert_eq!(usage.output_tokens, 163);
+        assert!((usage.cost_usd - 0.017286).abs() < 1e-6);
+    }
+
+    #[test]
+    fn result_without_model_usage_yields_none() {
+        let mut p = StreamParser::new();
+        p.feed(RESULT_LINE);
+        assert!(p.model_usage().is_none());
+    }
+
+    #[test]
+    fn non_result_message_does_not_set_model_usage() {
+        let mut p = StreamParser::new();
+        p.feed(ASSISTANT_WITH_USAGE);
+        assert!(p.model_usage().is_none());
+    }
+
+    #[test]
+    fn multi_model_result_picks_largest_context_window() {
+        let mut p = StreamParser::new();
+        p.feed(RESULT_MULTI_MODEL);
+        let usage = p.model_usage().expect("expected model usage");
+        assert_eq!(usage.context_window, 1_000_000);
+        assert_eq!(usage.input_tokens, 200);
+        assert_eq!(usage.output_tokens, 80);
+    }
+
+    #[test]
+    fn model_usage_persists_across_subsequent_feeds() {
+        let mut p = StreamParser::new();
+        p.feed(RESULT_WITH_MODEL_USAGE);
+        assert!(p.model_usage().is_some());
+        p.feed(TEXT_LINE);
+        assert!(
+            p.model_usage().is_some(),
+            "model_usage must persist after non-result feed"
+        );
+    }
+
+    #[test]
+    fn format_usage_with_percentage_typical() {
+        // 20000 / 200000 = 10.0% — exact, no rounding ambiguity
+        assert_eq!(
+            format_usage_with_percentage(20000, 200000),
+            "20.0k (10.0%) used"
+        );
+    }
+
+    #[test]
+    fn format_usage_with_percentage_zero_tokens() {
+        assert_eq!(format_usage_with_percentage(0, 200000), "0.0k (0.0%) used");
+    }
+
+    #[test]
+    fn format_usage_with_percentage_full_window() {
+        assert_eq!(
+            format_usage_with_percentage(200000, 200000),
+            "200.0k (100.0%) used"
+        );
+    }
+
+    #[test]
+    fn format_usage_with_percentage_zero_context_window() {
+        assert_eq!(format_usage_with_percentage(1000, 0), "1.0k (0.0%) used");
     }
 }

--- a/src/display.rs
+++ b/src/display.rs
@@ -38,6 +38,7 @@ struct DisplayState {
     model: String,
     start_time: Instant,
     token_warning: Option<String>,
+    usage_tokens: Option<u64>,
     active_tool_calls: Vec<(String, ToolCallEntry)>,
     offset_tracker: OffsetTracker,
 }
@@ -52,6 +53,7 @@ impl DisplayState {
             model: String::new(),
             start_time: Instant::now(),
             token_warning: None,
+            usage_tokens: None,
             active_tool_calls: Vec::new(),
             offset_tracker: OffsetTracker::new(),
         }
@@ -172,6 +174,7 @@ pub fn set_stage(name: &str, iteration: u32, model: &str) {
             state.model = model.to_owned();
             state.start_time = Instant::now();
             state.token_warning = None;
+            state.usage_tokens = None;
             state.active_tool_calls.clear();
             state.offset_tracker.clear();
         }
@@ -209,6 +212,7 @@ pub fn clear_stage() {
         state.iteration = 0;
         state.model.clear();
         state.token_warning = None;
+        state.usage_tokens = None;
         state.active_tool_calls.clear();
         state.offset_tracker.clear();
         let (info_r, status_r) = (state.info_row(), state.status_row());
@@ -223,6 +227,18 @@ pub fn set_token_warning(msg: Option<&str>) {
     let mut guard = get_state().lock().unwrap_or_else(|e| e.into_inner());
     if let Some(state) = guard.as_mut() {
         state.token_warning = msg.map(str::to_owned);
+        let (tw, info) = (state.term_width, state.info_row());
+        let info_text = build_info_text(state);
+        drop(guard);
+        draw_panel_info_row_to(&mut out, tw, info, &info_text);
+    }
+}
+
+pub fn set_usage(total_tokens: u64) {
+    let mut out = stdout().lock();
+    let mut guard = get_state().lock().unwrap_or_else(|e| e.into_inner());
+    if let Some(state) = guard.as_mut() {
+        state.usage_tokens = Some(total_tokens);
         let (tw, info) = (state.term_width, state.info_row());
         let info_text = build_info_text(state);
         drop(guard);
@@ -283,15 +299,28 @@ fn handle_resize_if_needed<W: Write + QueueableCommand>(
     false
 }
 
+fn format_token_count(total: u64) -> String {
+    if total >= 1_000_000 {
+        format!("{:.1}M used", total as f64 / 1_000_000.0)
+    } else if total >= 1_000 {
+        format!("{:.1}k used", total as f64 / 1_000.0)
+    } else {
+        format!("{total} used")
+    }
+}
+
 fn build_info_text(state: &DisplayState) -> String {
     let duration = state.start_time.elapsed();
-    let base = format!(
+    let mut base = format!(
         "Stage: {}  Iter: {}  Model: {}  Duration: {}",
         state.stage_name,
         state.iteration,
         state.model,
         format_duration(duration),
     );
+    if let Some(tokens) = state.usage_tokens {
+        base = format!("{base}  {}", format_token_count(tokens));
+    }
     if let Some(warn) = &state.token_warning {
         format!("{base}  ⚠ {warn}")
     } else {
@@ -1631,6 +1660,7 @@ mod tests {
             model: "claude-opus-4-6".to_string(),
             start_time: Instant::now(),
             token_warning: None,
+            usage_tokens: None,
             active_tool_calls: Vec::new(),
             offset_tracker: OffsetTracker::new(),
         };
@@ -1639,6 +1669,88 @@ mod tests {
         assert!(text.contains("3"), "iteration must appear");
         assert!(text.contains("claude-opus-4-6"), "model must appear");
         assert!(text.contains("00:"), "duration must appear in MM:SS format");
+    }
+
+    #[test]
+    fn format_token_count_zero() {
+        assert_eq!(format_token_count(0), "0 used");
+    }
+
+    #[test]
+    fn format_token_count_below_k_threshold() {
+        assert_eq!(format_token_count(999), "999 used");
+    }
+
+    #[test]
+    fn format_token_count_exactly_one_k() {
+        assert_eq!(format_token_count(1_000), "1.0k used");
+    }
+
+    #[test]
+    fn format_token_count_one_point_five_k() {
+        assert_eq!(format_token_count(1_500), "1.5k used");
+    }
+
+    #[test]
+    fn format_token_count_33k() {
+        assert_eq!(format_token_count(33_300), "33.3k used");
+    }
+
+    #[test]
+    fn format_token_count_128k() {
+        assert_eq!(format_token_count(128_000), "128.0k used");
+    }
+
+    #[test]
+    fn format_token_count_exactly_one_m() {
+        assert_eq!(format_token_count(1_000_000), "1.0M used");
+    }
+
+    #[test]
+    fn format_token_count_one_point_five_m() {
+        assert_eq!(format_token_count(1_500_000), "1.5M used");
+    }
+
+    #[test]
+    fn build_info_text_includes_usage_when_set() {
+        let state = DisplayState {
+            term_width: 80,
+            term_height: 24,
+            stage_name: "review".to_string(),
+            iteration: 2,
+            model: "opus".to_string(),
+            start_time: Instant::now(),
+            token_warning: None,
+            usage_tokens: Some(33_300),
+            active_tool_calls: Vec::new(),
+            offset_tracker: OffsetTracker::new(),
+        };
+        let text = build_info_text(&state);
+        assert!(
+            text.contains("33.3k used"),
+            "usage segment must appear when set; got: {text:?}"
+        );
+    }
+
+    #[test]
+    fn build_info_text_omits_usage_when_none() {
+        let state = DisplayState {
+            term_width: 80,
+            term_height: 24,
+            stage_name: "review".to_string(),
+            iteration: 2,
+            model: "opus".to_string(),
+            start_time: Instant::now(),
+            token_warning: None,
+            usage_tokens: None,
+            active_tool_calls: Vec::new(),
+            offset_tracker: OffsetTracker::new(),
+        };
+        let text = build_info_text(&state);
+        assert!(
+            !text.contains("used"),
+            "usage segment must be absent when None; got: {text:?}"
+        );
     }
 
     // ── wrap_text edge cases ──────────────────────────────────────────────────

--- a/src/run/mod.rs
+++ b/src/run/mod.rs
@@ -237,6 +237,14 @@ impl RunSession {
             _ => None,
         };
         summary::write_last_run(&self.cfg.capsule_dir, &result.summary, state_to_write)?;
+        if let Some(usage) = runner.model_usage() {
+            let total = usage.input_tokens + usage.output_tokens;
+            let formatted = capsule::container_execution::format_usage_with_percentage(
+                total,
+                usage.context_window,
+            );
+            capsule::display::capsule_info(&formatted);
+        }
         if let Some(hint) = summary::resume_hint(
             result.summary.session_id.as_deref(),
             &result.summary.terminal_reason,


### PR DESCRIPTION
## Parent
#179

## Summary
Extracts richer data from Claude Code's streaming JSON output and surfaces it to the user. Adds tool result content capture, live token usage in the status panel, and end-of-run context window percentage display.

- `ToolResultEvent` now captures the `content` field from tool result blocks (#188)
- `UsageSnapshot` extracted from assistant messages to track per-turn token counts (#189)
- Status panel info row displays live token usage (e.g. `33.3k used`) updated on every assistant message (#190)
- End-of-run `modelUsage` parsed to show context window percentage (e.g. `33.3k (16.6%) used`) (#191)

## Notes
- Usage resets on stage transitions — each stage shows its own consumption.
- Live percentage is intentionally omitted because `contextWindow` only arrives in the final `result` message.
- Multi-model runs pick the model with the largest context window for percentage calculation.