### PR TITLE
fix: remove stale resume argument from hint

### DIFF
--- a/src/run/summary.rs
+++ b/src/run/summary.rs
@@ -66,10 +66,10 @@ pub(super) fn parse_resume_state(capsule_dir: &Path) -> Result<(String, Pipeline
 }
 
 pub(super) fn resume_hint(session_id: Option<&str>, reason: &TerminalReason) -> Option<String> {
-    let id = session_id?;
+    session_id?;
     match reason {
         TerminalReason::FailExit | TerminalReason::CapHit => {
-            Some(format!("To continue the session, run: capsule resume {id}"))
+            Some("To continue the session, run: capsule resume".to_string())
         }
         _ => None,
     }
@@ -227,7 +227,7 @@ mod tests {
         let hint = resume_hint(Some("sess_abc"), &TerminalReason::FailExit);
         assert!(hint.is_some());
         let msg = hint.unwrap();
-        assert!(msg.contains("sess_abc"), "hint was: {msg}");
+        assert!(!msg.contains("sess_abc"), "hint was: {msg}");
         assert!(msg.contains("capsule resume"), "hint was: {msg}");
     }
 


### PR DESCRIPTION
## Summary

- print `capsule resume` without a stale session argument
- keep the hint gated on resumable runs
- update the existing unit test coverage

Fixes #197.

## Checks

- `cargo test resume_hint`
- `cargo fmt`
- `cargo clippy --tests -- -D warnings`
- `cargo test`