### PR TITLE
docs: simplify single-stage template prompt

### DIFF
--- a/templates/single-stage/.capsule/prompt.md
+++ b/templates/single-stage/.capsule/prompt.md
@@ -1,72 +1,7 @@
-# PROJECT
+# Fresh capsule project
 
-Describe your project here in 2-3 sentences. What it does, what language/framework it uses, and any key architectural constraints.
+This is a new, unconfigured capsule project.
 
-Follow all conventions in CLAUDE.md.
-
-# ISSUES
-
-GitHub issues are provided at start of context.
-
-Work through open issues one at a time.
-
-When all open tasks are complete, call `submit_verdict(status="pass", notes="Queue drained.")`.
-
-# CONSTRAINTS
-
-- Work on a single task per iteration. Do not start a second task.
-- Never commit directly to the main branch.
-- Never close or comment on issues you are not working on.
-- Never delete branches.
-- Never run release workflows.
-- Never commit code that doesn't pass tests.
-- When adding new dependencies, justify the choice in the commit message.
-- Prefer small, focused changes. If the issue requires extensive work, implement the smallest shippable piece and note the remaining work in an issue comment.
-- **When stuck**: If you cannot resolve a problem after two attempts, stop. Do not commit broken code. Leave a comment on the GitHub issue with: why you couldn't complete the task, what you tried, and what remains. Push any salvageable work and end the iteration.
-- **Issue comments** when incomplete: Lead with *why* the task couldn't be completed, then what was implemented, and what remains.
-
-# TASK SELECTION
-
-Pick the next task. Prioritize tasks in this order:
-
-1. Critical bugfixes
-2. Development infrastructure
-3. Tracer bullets for new features
-4. Polish and quick wins
-5. Refactors
-
-Once you pick a task, announce the task title and working branch.
-
-# BRANCH
-
-Read the "Working branch" field from the issue you are working on. Check out that branch and pull the latest changes before starting work.
-
-# IMPLEMENTATION
-
-Read the files relevant to the issue before starting implementation.
-
-Use /tdd for implementation and bug fixes. For documentation, config changes, or refactors already covered by existing tests, implement directly without /tdd.
-
-# FEEDBACK LOOPS
-
-Before committing, run the feedback loops:
-
-- Format code (e.g. `cargo fmt`, `prettier`, `ruff format`)
-- Lint (e.g. `cargo clippy -- -D warnings`, `eslint`, `ruff check`)
-- Run the test suite (e.g. `cargo test`, `npm test`, `pytest`)
-
-# COMMIT
-
-Make a git commit. The commit message must:
-
-1. Include what was done
-2. Include key decisions made
-3. Blockers or notes for next iteration
-
-# ISSUE HANDLING
-
-Push the branch.
-If there is no PR from this branch to the base branch, create one using `gh pr create`. Make sure to associate the PRD issue number in the body.
-
-If the task is complete, close the issue.
-If the task is not complete, leave a comment on the GitHub issue describing: why it couldn't be completed, what was done, and what remains.
+Tell the user to ask an AI agent to help set it up with `capsule explain`. Keep
+the response brief and suggest starting with `capsule explain` for the topic
+index or `capsule explain --all` for the full guide.

--- a/templates/single-stage/README.md
+++ b/templates/single-stage/README.md
@@ -1,13 +1,15 @@
-# Single-stage example
+# Single-stage template
 
-The simplest capsule setup: a single-stage config running one prompt per container. Each run picks an open GitHub issue, implements it, and commits.
+The simplest capsule setup: one stage with a short starter prompt for a fresh,
+unconfigured project. It points the user toward `capsule explain` instead of
+assuming any issue queue, branch rules, or commit process.
 
 ## Structure
 
 ```
 .capsule/
   config.yml        # single stage: stages: + prompt, model, github_token_from
-  prompt.md         # what Claude does each run
+  prompt.md         # brief setup hint for a fresh project
   Dockerfile        # extends the base capsule image with project-specific tooling
   .env              # GH_TOKEN and other secrets (not committed)
 ```
@@ -28,6 +30,7 @@ capsule run --model claude-opus-4-7
 ## Key concepts shown
 
 - **Single-stage config** — `stages:` with one named stage; simplest possible pipeline
+- **Starter prompt** — a brief default message that sends users to `capsule explain` for setup guidance
 - **Custom `Dockerfile`** — extends the base image with project-specific runtimes or tools
 
 For multi-stage pipelines and the full ralph loop pattern, see [`../ralph-loop`](../ralph-loop).

--- a/tests/templates.rs
+++ b/tests/templates.rs
@@ -1,4 +1,5 @@
 use assert_cmd::Command;
+use capsule::templates;
 
 fn cmd() -> Command {
     Command::cargo_bin("capsule").unwrap()
@@ -36,5 +37,26 @@ fn templates_list_shows_footer() {
     assert!(
         stdout.contains("capsule explain pipeline-shapes"),
         "missing footer guidance"
+    );
+}
+
+#[test]
+fn single_stage_prompt_points_to_explain_without_issue_workflow() {
+    let dir = tempfile::tempdir().unwrap();
+    templates::copy_to("single-stage", dir.path()).unwrap();
+
+    let prompt = std::fs::read_to_string(dir.path().join("prompt.md")).unwrap();
+
+    assert!(
+        prompt.contains("capsule explain"),
+        "prompt should point users to capsule explain"
+    );
+    assert!(
+        !prompt.contains("GitHub issues are provided"),
+        "prompt should not assume GitHub issues are injected"
+    );
+    assert!(
+        !prompt.contains("Working branch"),
+        "prompt should not prescribe branch handling"
     );
 }


### PR DESCRIPTION
## Summary
- replace the single-stage template's issue-driven prompt with a brief fresh-project setup hint
- point users toward `capsule explain` for setup guidance
- update the template README and add regression coverage for the default prompt

Fixes #263.

## Validation
- `cargo fmt --all -- --check`
- `cargo test single_stage_prompt_points_to_explain_without_issue_workflow`
- `cargo test templates`
- `cargo test check_all_embedded_templates_pass`
- `cargo clippy --tests -- -D warnings`
- `env -u NO_COLOR TERM=xterm-256color cargo test`
- `git diff --check HEAD~1 HEAD`
- `git show --format= --patch HEAD | gitleaks stdin --no-banner --redact --timeout 30`

## Notes
- Plain `cargo test` in this shell fails unrelated display color assertions because `NO_COLOR=1` and `TERM=dumb`; rerunning with `NO_COLOR` unset and a color-capable `TERM` passes.
- This is a template/docs/test change; no `capsule run` smoke was performed.