### PR TITLE
Group sub-agent tool calls under parent Agent call

### DIFF
--- a/docs/adr/0008-scroll-region-display-architecture.md
+++ b/docs/adr/0008-scroll-region-display-architecture.md
@@ -27,6 +27,7 @@ The original design placed tool call dots in the status panel. This was a misund
 - **Completed**: dot updated in-place to solid green (success) or red (failure) via offset counting + `MoveUp(N)`, with a sub-line showing duration
 - **Offset counting**: capsule is the sole writer to the scroll region, so line offsets are reliable. Each pending tool call stores its offset; all offsets increment on every scroll-region write. If a tool call scrolls off-screen (offset > scroll region height), the in-place update is skipped.
 - **Multiple pending calls**: no cap; each tracked by ID with its own offset
+- **Nested tool calls**: when a tool call carries a `parent_tool_use_id` (sub-agent invocations), the display prefixes it with `├─ ` and derives nesting depth from the parent's entry. Both TTY and non-TTY paths render the prefix; offset tracking accounts for the extra prefix width
 
 ## References
 

--- a/examples/display_demo.rs
+++ b/examples/display_demo.rs
@@ -76,22 +76,22 @@ fn main() {
 
     // --- tool call states ---
     section("Tool call states");
-    display::tool_call("Read", "src/main.rs", "s-1");
-    display::tool_call("Read", "src/lib.rs", "s-2");
+    display::tool_call("Read", "src/main.rs", "s-1", None);
+    display::tool_call("Read", "src/lib.rs", "s-2", None);
     display::tool_result("s-1", true);
     display::tool_result("s-2", true);
-    display::tool_call("Bash", "cargo test", "s-3");
+    display::tool_call("Bash", "cargo test", "s-3", None);
     display::tool_result("s-3", false);
 
     // --- tool calls (overlapping) ---
     section("Tool calls — overlapping");
-    display::tool_call("Read", "src/main.rs", "tc-1");
+    display::tool_call("Read", "src/main.rs", "tc-1", None);
     pause(500);
-    display::tool_call("Bash", "cargo test --lib", "tc-2");
+    display::tool_call("Bash", "cargo test --lib", "tc-2", None);
     pause(800);
     display::tool_result("tc-1", true);
     pause(400);
-    display::tool_call("Edit", "src/display.rs  old_string=…", "tc-3");
+    display::tool_call("Edit", "src/display.rs  old_string=…", "tc-3", None);
     pause(600);
     display::tool_result("tc-2", false);
     pause(400);

--- a/src/container_execution/process.rs
+++ b/src/container_execution/process.rs
@@ -64,7 +64,12 @@ fn stream_output(reader: BufReader<impl std::io::Read>, verbose: bool) -> Result
             match event {
                 ToolEvent::Use(tu) => {
                     let args = format_tool_args(&tu.input);
-                    crate::display::tool_call(&tu.name, &args, &tu.id);
+                    crate::display::tool_call(
+                        &tu.name,
+                        &args,
+                        &tu.id,
+                        tu.parent_tool_use_id.as_deref(),
+                    );
                 }
                 ToolEvent::Result(tr) => {
                     crate::display::tool_result(&tr.tool_use_id, !tr.is_error);

--- a/src/container_execution/stream_parser.rs
+++ b/src/container_execution/stream_parser.rs
@@ -5,6 +5,7 @@ pub struct ToolUseEvent {
     pub id: String,
     pub name: String,
     pub input: Value,
+    pub parent_tool_use_id: Option<String>,
 }
 
 pub struct ToolResultEvent {
@@ -219,6 +220,10 @@ fn extract_assistant_content(msg: &Value) -> (Vec<ToolEvent>, Vec<TextDisplay>) 
             let Some(content) = msg.pointer("/message/content").and_then(Value::as_array) else {
                 return (Vec::new(), Vec::new());
             };
+            let parent_tool_use_id = msg
+                .get("parent_tool_use_id")
+                .and_then(Value::as_str)
+                .map(str::to_owned);
             let mut tool_events = Vec::new();
             let mut text_displays = Vec::new();
             for block in content {
@@ -229,7 +234,12 @@ fn extract_assistant_content(msg: &Value) -> (Vec<ToolEvent>, Vec<TextDisplay>) 
                             block.get("id").and_then(Value::as_str).map(str::to_owned),
                             block.get("input").cloned(),
                         ) {
-                            tool_events.push(ToolEvent::Use(ToolUseEvent { id, name, input }));
+                            tool_events.push(ToolEvent::Use(ToolUseEvent {
+                                id,
+                                name,
+                                input,
+                                parent_tool_use_id: parent_tool_use_id.clone(),
+                            }));
                         }
                     }
                     Some("text") => {
@@ -1097,5 +1107,46 @@ mod tests {
     #[test]
     fn format_usage_with_percentage_zero_context_window() {
         assert_eq!(format_usage_with_percentage(1000, 0), "1.0k (0.0%) used");
+    }
+
+    #[test]
+    fn parent_tool_use_id_extracted_from_message_envelope() {
+        let line = r#"{"type":"assistant","parent_tool_use_id":"toolu_agent01","message":{"content":[{"type":"tool_use","id":"toolu_child01","name":"Bash","input":{"command":"ls"}}]}}"#;
+        let mut p = StreamParser::new();
+        p.feed(line);
+        let events = p.last_tool_events();
+        assert_eq!(events.len(), 1);
+        let ToolEvent::Use(tu) = &events[0] else {
+            panic!("expected ToolEvent::Use");
+        };
+        assert_eq!(tu.parent_tool_use_id.as_deref(), Some("toolu_agent01"));
+    }
+
+    #[test]
+    fn parent_tool_use_id_is_none_when_absent() {
+        let line = r#"{"type":"assistant","message":{"content":[{"type":"tool_use","id":"toolu_01","name":"Bash","input":{"command":"ls"}}]}}"#;
+        let mut p = StreamParser::new();
+        p.feed(line);
+        let events = p.last_tool_events();
+        assert_eq!(events.len(), 1);
+        let ToolEvent::Use(tu) = &events[0] else {
+            panic!("expected ToolEvent::Use");
+        };
+        assert!(tu.parent_tool_use_id.is_none());
+    }
+
+    #[test]
+    fn parent_tool_use_id_propagated_to_all_tool_uses_in_message() {
+        let line = r#"{"type":"assistant","parent_tool_use_id":"toolu_agent01","message":{"content":[{"type":"tool_use","id":"toolu_child01","name":"Bash","input":{"command":"ls"}},{"type":"tool_use","id":"toolu_child02","name":"Read","input":{"path":"/tmp/foo"}}]}}"#;
+        let mut p = StreamParser::new();
+        p.feed(line);
+        let events = p.last_tool_events();
+        assert_eq!(events.len(), 2);
+        for event in events {
+            let ToolEvent::Use(tu) = event else {
+                panic!("expected ToolEvent::Use");
+            };
+            assert_eq!(tu.parent_tool_use_id.as_deref(), Some("toolu_agent01"));
+        }
     }
 }

--- a/src/display.rs
+++ b/src/display.rs
@@ -29,6 +29,8 @@ struct ToolCallEntry {
     name: String,
     args: String,
     start_time: Instant,
+    #[allow(dead_code)]
+    parent_tool_use_id: Option<String>,
 }
 
 struct DisplayState {
@@ -709,7 +711,7 @@ fn render_tty_tool_result_to<W: Write + QueueableCommand>(
     out.flush()
 }
 
-pub fn tool_call(name: &str, args: &str, id: &str) {
+pub fn tool_call(name: &str, args: &str, id: &str, parent_tool_use_id: Option<&str>) {
     LAST_WAS_TEXT.store(false, Ordering::Relaxed);
 
     let display_args: String = if args.chars().count() > TOOL_ARGS_MAX {
@@ -738,6 +740,7 @@ pub fn tool_call(name: &str, args: &str, id: &str) {
                 name: name.to_owned(),
                 args: display_args.clone(),
                 start_time: Instant::now(),
+                parent_tool_use_id: parent_tool_use_id.map(str::to_owned),
             },
         ));
         drop(guard);
@@ -753,6 +756,7 @@ pub fn tool_call(name: &str, args: &str, id: &str) {
                     name: name.to_owned(),
                     args: display_args.clone(),
                     start_time: Instant::now(),
+                    parent_tool_use_id: parent_tool_use_id.map(str::to_owned),
                 },
             );
         tool_call_to(&mut out, name, &display_args).ok();

--- a/src/display.rs
+++ b/src/display.rs
@@ -29,8 +29,7 @@ struct ToolCallEntry {
     name: String,
     args: String,
     start_time: Instant,
-    #[allow(dead_code)]
-    parent_tool_use_id: Option<String>,
+    nesting_depth: u16,
 }
 
 struct DisplayState {
@@ -659,13 +658,29 @@ fn notice_box_to<W: Write + QueueableCommand>(
 }
 
 const TOOL_ARGS_MAX: usize = 60;
+const NESTING_PREFIX: &str = "├─ ";
+const NESTING_PREFIX_LEN: usize = 3;
+
+fn nesting_prefix(depth: u16) -> &'static str {
+    if depth > 0 {
+        NESTING_PREFIX
+    } else {
+        ""
+    }
+}
 
 fn render_tty_tool_call_to<W: Write + QueueableCommand>(
     out: &mut W,
     name: &str,
     display_args: &str,
+    depth: u16,
 ) -> std::io::Result<()> {
     out.queue(Print("\n"))?;
+    if depth > 0 {
+        out.queue(SetForegroundColor(Color::DarkGrey))?;
+        out.queue(Print(NESTING_PREFIX))?;
+        out.queue(ResetColor)?;
+    }
     out.queue(SetAttribute(Attribute::SlowBlink))?;
     out.queue(SetForegroundColor(Color::DarkGrey))?;
     out.queue(Print("●"))?;
@@ -681,9 +696,11 @@ fn render_tty_tool_result_to<W: Write + QueueableCommand>(
     duration: Duration,
     success: bool,
     offset: Option<u16>,
+    depth: u16,
 ) -> std::io::Result<()> {
     let color = if success { GREEN } else { RED };
     let label = if success { "Done" } else { "Failed" };
+    let prefix = nesting_prefix(depth);
 
     match offset {
         Some(n) => {
@@ -691,6 +708,11 @@ fn render_tty_tool_result_to<W: Write + QueueableCommand>(
             out.queue(cursor::MoveUp(n))?;
             out.queue(cursor::MoveToColumn(0))?;
             out.queue(terminal::Clear(ClearType::CurrentLine))?;
+            if depth > 0 {
+                out.queue(SetForegroundColor(Color::DarkGrey))?;
+                out.queue(Print(prefix))?;
+                out.queue(ResetColor)?;
+            }
             out.queue(SetForegroundColor(color))?;
             out.queue(Print("●"))?;
             out.queue(ResetColor)?;
@@ -698,6 +720,11 @@ fn render_tty_tool_result_to<W: Write + QueueableCommand>(
             out.queue(cursor::RestorePosition)?;
         }
         None => {
+            if depth > 0 {
+                out.queue(SetForegroundColor(Color::DarkGrey))?;
+                out.queue(Print(prefix))?;
+                out.queue(ResetColor)?;
+            }
             out.queue(SetForegroundColor(color))?;
             out.queue(Print("●"))?;
             out.queue(ResetColor)?;
@@ -720,14 +747,25 @@ pub fn tool_call(name: &str, args: &str, id: &str, parent_tool_use_id: Option<&s
     } else {
         args.to_owned()
     };
-    log_line(&format!("\n● {name}  {display_args}"));
 
     let mut out = stdout().lock();
     let mut guard = get_state().lock().unwrap_or_else(|e| e.into_inner());
     handle_resize_if_needed(&mut guard, &mut out);
     if let Some(state) = guard.as_mut() {
+        let nesting_depth = parent_tool_use_id
+            .and_then(|pid| state.active_tool_calls.iter().find(|(eid, _)| eid == pid))
+            .map(|(_, e)| e.nesting_depth + 1)
+            .unwrap_or(0);
+        let prefix_len = if nesting_depth > 0 {
+            NESTING_PREFIX_LEN
+        } else {
+            0
+        };
+        let prefix = nesting_prefix(nesting_depth);
+        log_line(&format!("\n{prefix}● {name}  {display_args}"));
         state.offset_tracker.increment_all(1, state.term_width); // blank line
-        let visible_width = 2 + name.chars().count() + 2 + display_args.chars().count();
+        let visible_width =
+            prefix_len + 2 + name.chars().count() + 2 + display_args.chars().count();
         state
             .offset_tracker
             .increment_all(visible_width, state.term_width);
@@ -740,13 +778,22 @@ pub fn tool_call(name: &str, args: &str, id: &str, parent_tool_use_id: Option<&s
                 name: name.to_owned(),
                 args: display_args.clone(),
                 start_time: Instant::now(),
-                parent_tool_use_id: parent_tool_use_id.map(str::to_owned),
+                nesting_depth,
             },
         ));
         drop(guard);
-        render_tty_tool_call_to(&mut out, name, &display_args).ok();
+        render_tty_tool_call_to(&mut out, name, &display_args, nesting_depth).ok();
     } else {
         drop(guard);
+        let nesting_depth = {
+            let cache = tool_call_cache().lock().unwrap_or_else(|e| e.into_inner());
+            parent_tool_use_id
+                .and_then(|pid| cache.get(pid))
+                .map(|e| e.nesting_depth + 1)
+                .unwrap_or(0)
+        };
+        let prefix = nesting_prefix(nesting_depth);
+        log_line(&format!("\n{prefix}● {name}  {display_args}"));
         tool_call_cache()
             .lock()
             .unwrap_or_else(|e| e.into_inner())
@@ -756,10 +803,10 @@ pub fn tool_call(name: &str, args: &str, id: &str, parent_tool_use_id: Option<&s
                     name: name.to_owned(),
                     args: display_args.clone(),
                     start_time: Instant::now(),
-                    parent_tool_use_id: parent_tool_use_id.map(str::to_owned),
+                    nesting_depth,
                 },
             );
-        tool_call_to(&mut out, name, &display_args).ok();
+        tool_call_to(&mut out, name, &display_args, nesting_depth).ok();
     }
 }
 
@@ -767,8 +814,12 @@ fn tool_call_to<W: Write + QueueableCommand>(
     out: &mut W,
     name: &str,
     display_args: &str,
+    depth: u16,
 ) -> std::io::Result<()> {
     out.queue(Print("\n"))?;
+    if depth > 0 {
+        out.queue(Print(NESTING_PREFIX))?;
+    }
     out.queue(SetForegroundColor(YELLOW))?;
     out.queue(Print("● "))?;
     out.queue(ResetColor)?;
@@ -788,9 +839,9 @@ pub fn tool_result(id: &str, success: bool) {
             .iter()
             .position(|(eid, _)| eid == id);
         let entry = entry_pos.map(|i| state.active_tool_calls.remove(i));
-        let (name, args, duration) = match entry {
-            Some((_, e)) => (e.name, e.args, e.start_time.elapsed()),
-            None => ("unknown".to_owned(), String::new(), Duration::ZERO),
+        let (name, args, duration, nesting_depth) = match entry {
+            Some((_, e)) => (e.name, e.args, e.start_time.elapsed(), e.nesting_depth),
+            None => ("unknown".to_owned(), String::new(), Duration::ZERO, 0),
         };
         let scroll_height = state.separator_row();
         let offset = state.offset_tracker.get_offset(id, scroll_height);
@@ -798,8 +849,17 @@ pub fn tool_result(id: &str, success: bool) {
         let tw = state.term_width;
         drop(guard);
 
-        render_tty_tool_result_to(&mut out, &name, &args, duration, success, offset).ok();
-        log_tool_result(&name, &args, duration, success);
+        render_tty_tool_result_to(
+            &mut out,
+            &name,
+            &args,
+            duration,
+            success,
+            offset,
+            nesting_depth,
+        )
+        .ok();
+        log_tool_result(&name, &args, duration, success, nesting_depth);
 
         // Account for the sub-line (and the solid-dot line in the off-screen case).
         let label = if success { "Done" } else { "Failed" };
@@ -810,7 +870,13 @@ pub fn tool_result(id: &str, success: bool) {
         if let Some(state) = guard.as_mut() {
             if offset.is_none() {
                 // Off-screen path wrote 2 lines: solid dot + sub-line.
-                let line1_visible = 2 + name.chars().count() + 2 + args.chars().count();
+                let prefix_len = if nesting_depth > 0 {
+                    NESTING_PREFIX_LEN
+                } else {
+                    0
+                };
+                let line1_visible =
+                    prefix_len + 2 + name.chars().count() + 2 + args.chars().count();
                 state.offset_tracker.increment_all(line1_visible, tw);
             }
             state.offset_tracker.increment_all(sub_visible, tw);
@@ -821,18 +887,19 @@ pub fn tool_result(id: &str, success: bool) {
             .lock()
             .unwrap_or_else(|e| e.into_inner())
             .remove(id);
-        let (name, args, duration) = match info {
-            Some(i) => (i.name, i.args, i.start_time.elapsed()),
-            None => ("unknown".to_owned(), String::new(), Duration::ZERO),
+        let (name, args, duration, nesting_depth) = match info {
+            Some(i) => (i.name, i.args, i.start_time.elapsed(), i.nesting_depth),
+            None => ("unknown".to_owned(), String::new(), Duration::ZERO, 0),
         };
-        tool_result_to(&mut out, &name, &args, duration, success).ok();
-        log_tool_result(&name, &args, duration, success);
+        tool_result_to(&mut out, &name, &args, duration, success, nesting_depth).ok();
+        log_tool_result(&name, &args, duration, success, nesting_depth);
     }
 }
 
-fn log_tool_result(name: &str, args: &str, duration: Duration, success: bool) {
+fn log_tool_result(name: &str, args: &str, duration: Duration, success: bool, depth: u16) {
     let status = if success { "Done" } else { "Failed" };
-    log_line(&format!("● {name}  {args}"));
+    let prefix = nesting_prefix(depth);
+    log_line(&format!("{prefix}● {name}  {args}"));
     log_line(&format!("  {status} ({:.1}s)", duration.as_secs_f64()));
 }
 
@@ -842,9 +909,13 @@ fn tool_result_to<W: Write + QueueableCommand>(
     args: &str,
     duration: Duration,
     success: bool,
+    depth: u16,
 ) -> std::io::Result<()> {
     let color = if success { GREEN } else { RED };
     let status = if success { "Done" } else { "Failed" };
+    if depth > 0 {
+        out.queue(Print(NESTING_PREFIX))?;
+    }
     out.queue(SetForegroundColor(color))?;
     out.queue(Print("● "))?;
     out.queue(ResetColor)?;
@@ -1371,7 +1442,7 @@ mod tests {
     #[test]
     fn tool_call_renders_name_and_args() {
         let mut buf: Vec<u8> = Vec::new();
-        tool_call_to(&mut buf, "Bash", "ls -la").unwrap();
+        tool_call_to(&mut buf, "Bash", "ls -la", 0).unwrap();
         let out = String::from_utf8_lossy(&buf);
         assert!(out.contains("Bash"), "tool name must appear in output");
         assert!(out.contains("ls -la"), "args must appear in output");
@@ -1384,7 +1455,7 @@ mod tests {
         let truncated: String = long_args.chars().take(TOOL_ARGS_MAX).collect();
         let display_args = format!("{truncated}…");
         let mut buf: Vec<u8> = Vec::new();
-        tool_call_to(&mut buf, "Bash", &display_args).unwrap();
+        tool_call_to(&mut buf, "Bash", &display_args, 0).unwrap();
         let out = String::from_utf8_lossy(&buf);
         assert!(out.contains("…"), "truncated args must end with ellipsis");
         assert!(
@@ -1397,16 +1468,45 @@ mod tests {
     fn tool_call_short_args_not_truncated() {
         let short_args = "short";
         let mut buf: Vec<u8> = Vec::new();
-        tool_call_to(&mut buf, "Read", short_args).unwrap();
+        tool_call_to(&mut buf, "Read", short_args, 0).unwrap();
         let out = String::from_utf8_lossy(&buf);
         assert!(out.contains(short_args), "short args must appear verbatim");
         assert!(!out.contains("…"), "short args must not be truncated");
     }
 
     #[test]
+    fn tool_call_depth_zero_no_prefix() {
+        let mut buf: Vec<u8> = Vec::new();
+        tool_call_to(&mut buf, "Bash", "ls", 0).unwrap();
+        let out = String::from_utf8_lossy(&buf);
+        assert!(
+            !out.contains("├"),
+            "depth-0 call must not emit nesting prefix"
+        );
+    }
+
+    #[test]
+    fn tool_call_depth_nonzero_emits_prefix() {
+        let mut buf: Vec<u8> = Vec::new();
+        tool_call_to(&mut buf, "Bash", "ls", 1).unwrap();
+        let out = String::from_utf8_lossy(&buf);
+        assert!(out.contains("├─"), "depth-1 call must emit nesting prefix");
+        assert!(out.contains("●"), "dot must still appear after prefix");
+        assert!(out.contains("Bash"), "tool name must appear");
+    }
+
+    #[test]
     fn tool_result_non_tty_no_cursor_up_emits_green_dot() {
         let mut buf: Vec<u8> = Vec::new();
-        tool_result_to(&mut buf, "Bash", "ls -la", Duration::from_millis(123), true).unwrap();
+        tool_result_to(
+            &mut buf,
+            "Bash",
+            "ls -la",
+            Duration::from_millis(123),
+            true,
+            0,
+        )
+        .unwrap();
         let out = String::from_utf8_lossy(&buf);
         assert!(
             !buf.windows(4).any(|w| w == b"\x1b[1A"),
@@ -1432,6 +1532,7 @@ mod tests {
             "path/to/file",
             Duration::from_millis(456),
             false,
+            0,
         )
         .unwrap();
         let out = String::from_utf8_lossy(&buf);
@@ -1450,6 +1551,35 @@ mod tests {
             contains_seq(&buf, RED_ANSI),
             "red escape must be emitted for failure; output: {out:?}"
         );
+    }
+
+    #[test]
+    fn tool_result_non_tty_depth_zero_no_prefix() {
+        let mut buf: Vec<u8> = Vec::new();
+        tool_result_to(&mut buf, "Bash", "ls", Duration::from_millis(100), true, 0).unwrap();
+        let out = String::from_utf8_lossy(&buf);
+        assert!(!out.contains("├"), "depth-0 result must not emit prefix");
+    }
+
+    #[test]
+    fn tool_result_non_tty_depth_nonzero_emits_prefix() {
+        let mut buf: Vec<u8> = Vec::new();
+        tool_result_to(
+            &mut buf,
+            "Read",
+            "file.rs",
+            Duration::from_millis(50),
+            true,
+            1,
+        )
+        .unwrap();
+        let out = String::from_utf8_lossy(&buf);
+        assert!(
+            out.contains("├─"),
+            "depth-1 result must emit nesting prefix"
+        );
+        assert!(out.contains("●"), "dot must still appear");
+        assert!(out.contains("Read"), "tool name must appear");
     }
 
     #[test]
@@ -2238,7 +2368,7 @@ mod tests {
     #[test]
     fn tty_tool_call_emits_slow_blink_and_dark_grey_dot() {
         let mut buf: Vec<u8> = Vec::new();
-        render_tty_tool_call_to(&mut buf, "Bash", "ls -la").unwrap();
+        render_tty_tool_call_to(&mut buf, "Bash", "ls -la", 0).unwrap();
         let out = String::from_utf8_lossy(&buf);
         assert!(
             contains_seq(&buf, BLINK_ANSI),
@@ -2257,7 +2387,7 @@ mod tests {
     #[test]
     fn tty_tool_call_includes_name_and_args() {
         let mut buf: Vec<u8> = Vec::new();
-        render_tty_tool_call_to(&mut buf, "Read", "src/main.rs").unwrap();
+        render_tty_tool_call_to(&mut buf, "Read", "src/main.rs", 0).unwrap();
         let out = String::from_utf8_lossy(&buf);
         assert!(
             out.contains("Read"),
@@ -2271,6 +2401,28 @@ mod tests {
     }
 
     #[test]
+    fn tty_tool_call_depth_zero_no_prefix() {
+        let mut buf: Vec<u8> = Vec::new();
+        render_tty_tool_call_to(&mut buf, "Bash", "ls", 0).unwrap();
+        let out = String::from_utf8_lossy(&buf);
+        assert!(!out.contains("├"), "depth-0 TTY call must not emit prefix");
+    }
+
+    #[test]
+    fn tty_tool_call_depth_nonzero_emits_prefix_before_dot() {
+        let mut buf: Vec<u8> = Vec::new();
+        render_tty_tool_call_to(&mut buf, "Read", "file.rs", 1).unwrap();
+        let out = String::from_utf8_lossy(&buf);
+        assert!(
+            out.contains("├─"),
+            "depth-1 TTY call must emit prefix; output: {out:?}"
+        );
+        let prefix_pos = out.find("├─").expect("prefix must be present");
+        let dot_pos = out.find('●').expect("dot must be present");
+        assert!(prefix_pos < dot_pos, "prefix must appear before dot");
+    }
+
+    #[test]
     fn tty_tool_result_in_place_emits_cursor_up() {
         let mut buf: Vec<u8> = Vec::new();
         render_tty_tool_result_to(
@@ -2280,6 +2432,7 @@ mod tests {
             Duration::from_millis(200),
             true,
             Some(3),
+            0,
         )
         .unwrap();
         let out = String::from_utf8_lossy(&buf);
@@ -2300,6 +2453,7 @@ mod tests {
             Duration::from_millis(200),
             true,
             Some(2),
+            0,
         )
         .unwrap();
         let out = String::from_utf8_lossy(&buf);
@@ -2327,6 +2481,7 @@ mod tests {
             Duration::from_millis(300),
             false,
             Some(1),
+            0,
         )
         .unwrap();
         let out = String::from_utf8_lossy(&buf);
@@ -2350,6 +2505,7 @@ mod tests {
             Duration::from_millis(100),
             true,
             None,
+            0,
         )
         .unwrap();
         let out = String::from_utf8_lossy(&buf);
@@ -2379,6 +2535,7 @@ mod tests {
             Duration::from_millis(450),
             true,
             None,
+            0,
         )
         .unwrap();
         let out = String::from_utf8_lossy(&buf);
@@ -2412,6 +2569,7 @@ mod tests {
             Duration::from_millis(50),
             true,
             Some(5),
+            0,
         )
         .unwrap();
         let out = String::from_utf8_lossy(&buf);
@@ -2419,5 +2577,45 @@ mod tests {
             out.contains("my/special/path.rs"),
             "args must be preserved in the in-place updated line; output: {out:?}"
         );
+    }
+
+    #[test]
+    fn tty_tool_result_depth_nonzero_emits_prefix_off_screen() {
+        let mut buf: Vec<u8> = Vec::new();
+        render_tty_tool_result_to(
+            &mut buf,
+            "Read",
+            "file.rs",
+            Duration::from_millis(100),
+            true,
+            None,
+            1,
+        )
+        .unwrap();
+        let out = String::from_utf8_lossy(&buf);
+        assert!(
+            out.contains("├─"),
+            "depth-1 off-screen result must emit prefix; output: {out:?}"
+        );
+        let prefix_pos = out.find("├─").expect("prefix must be present");
+        let dot_pos = out.find('●').expect("dot must be present");
+        assert!(prefix_pos < dot_pos, "prefix must appear before dot");
+    }
+
+    #[test]
+    fn tty_tool_result_depth_zero_off_screen_no_prefix() {
+        let mut buf: Vec<u8> = Vec::new();
+        render_tty_tool_result_to(
+            &mut buf,
+            "Read",
+            "file.rs",
+            Duration::from_millis(100),
+            true,
+            None,
+            0,
+        )
+        .unwrap();
+        let out = String::from_utf8_lossy(&buf);
+        assert!(!out.contains("├"), "depth-0 result must not emit prefix");
     }
 }

--- a/src/display.rs
+++ b/src/display.rs
@@ -763,7 +763,7 @@ pub fn tool_call(name: &str, args: &str, id: &str, parent_tool_use_id: Option<&s
         };
         let prefix = nesting_prefix(nesting_depth);
         log_line(&format!("\n{prefix}● {name}  {display_args}"));
-        state.offset_tracker.increment_all(1, state.term_width); // blank line
+        state.offset_tracker.increment_all(1, state.term_width);
         let visible_width =
             prefix_len + 2 + name.chars().count() + 2 + display_args.chars().count();
         state
@@ -959,7 +959,7 @@ pub fn agent_text(text: &str) {
     let mut guard = get_state().lock().unwrap_or_else(|e| e.into_inner());
     if let Some(state) = guard.as_mut() {
         if !was_text {
-            state.offset_tracker.increment_all(1, state.term_width); // blank line
+            state.offset_tracker.increment_all(1, state.term_width);
         }
         for line in &wrapped {
             let vw = 2 + line.chars().count();


### PR DESCRIPTION
## Parent
Closes #267

## Summary
Visually groups sub-agent tool calls under their parent `Agent` call using tree-drawing prefixes (`├─`) before the status dot. The stream parser now extracts `parent_tool_use_id` from message envelopes and threads it through to the display layer, which tracks nesting depth and renders the appropriate prefixes for both TTY and non-TTY outputs.

## Notes
- Implemented across two commits: #270 (stream extraction) and #271 (display rendering)
- Nesting depth is tracked per tool call entry, supporting parallel sub-agents with independent groups
- The status dot retains its role (blinking → green/red) regardless of nesting