### PR TITLE
fix: polish terminal output formatting

### DIFF
--- a/docs/adr/0008-scroll-region-display-architecture.md
+++ b/docs/adr/0008-scroll-region-display-architecture.md
@@ -27,6 +27,7 @@ The original design placed tool call dots in the status panel. This was a misund
 - **Completed**: dot updated in-place to solid green (success) or red (failure) via offset counting + `MoveUp(N)`, with a sub-line showing duration
 - **Offset counting**: capsule is the sole writer to the scroll region, so line offsets are reliable. Each pending tool call stores its offset; all offsets increment on every scroll-region write. If a tool call scrolls off-screen (offset > scroll region height), the in-place update is skipped.
 - **Multiple pending calls**: no cap; each tracked by ID with its own offset
+- **Nested tool calls**: when a tool call carries a `parent_tool_use_id` (sub-agent invocations), the display prefixes it with `├─ ` and derives nesting depth from the parent's entry. Both TTY and non-TTY paths render the prefix; offset tracking accounts for the extra prefix width
 
 ## References
 

--- a/docs/adr/0008-scroll-region-display-architecture.md
+++ b/docs/adr/0008-scroll-region-display-architecture.md
@@ -27,7 +27,7 @@ The original design placed tool call dots in the status panel. This was a misund
 - **Completed**: dot updated in-place to solid green (success) or red (failure) via offset counting + `MoveUp(N)`, with a sub-line showing duration
 - **Offset counting**: capsule is the sole writer to the scroll region, so line offsets are reliable. Each pending tool call stores its offset; all offsets increment on every scroll-region write. If a tool call scrolls off-screen (offset > scroll region height), the in-place update is skipped.
 - **Multiple pending calls**: no cap; each tracked by ID with its own offset
-- **Nested tool calls**: when a tool call carries a `parent_tool_use_id` (sub-agent invocations), the display prefixes it with `├─ ` and derives nesting depth from the parent's entry. Both TTY and non-TTY paths render the prefix; offset tracking accounts for the extra prefix width
+- **Nested tool calls**: when a tool call carries a `parent_tool_use_id` (sub-agent invocations), the display derives nesting depth from the parent's entry and renders a multi-level prefix (`│  ` per ancestor level, then `├─ `). Both TTY and non-TTY paths render the prefix; offset tracking accounts for the prefix width
 
 ## References
 

--- a/examples/display_demo.rs
+++ b/examples/display_demo.rs
@@ -76,22 +76,22 @@ fn main() {
 
     // --- tool call states ---
     section("Tool call states");
-    display::tool_call("Read", "src/main.rs", "s-1");
-    display::tool_call("Read", "src/lib.rs", "s-2");
+    display::tool_call("Read", "src/main.rs", "s-1", None);
+    display::tool_call("Read", "src/lib.rs", "s-2", None);
     display::tool_result("s-1", true);
     display::tool_result("s-2", true);
-    display::tool_call("Bash", "cargo test", "s-3");
+    display::tool_call("Bash", "cargo test", "s-3", None);
     display::tool_result("s-3", false);
 
     // --- tool calls (overlapping) ---
     section("Tool calls — overlapping");
-    display::tool_call("Read", "src/main.rs", "tc-1");
+    display::tool_call("Read", "src/main.rs", "tc-1", None);
     pause(500);
-    display::tool_call("Bash", "cargo test --lib", "tc-2");
+    display::tool_call("Bash", "cargo test --lib", "tc-2", None);
     pause(800);
     display::tool_result("tc-1", true);
     pause(400);
-    display::tool_call("Edit", "src/display.rs  old_string=…", "tc-3");
+    display::tool_call("Edit", "src/display.rs  old_string=…", "tc-3", None);
     pause(600);
     display::tool_result("tc-2", false);
     pause(400);

--- a/src/container_execution/process.rs
+++ b/src/container_execution/process.rs
@@ -64,7 +64,12 @@ fn stream_output(reader: BufReader<impl std::io::Read>, verbose: bool) -> Result
             match event {
                 ToolEvent::Use(tu) => {
                     let args = format_tool_args(&tu.input);
-                    crate::display::tool_call(&tu.name, &args, &tu.id);
+                    crate::display::tool_call(
+                        &tu.name,
+                        &args,
+                        &tu.id,
+                        tu.parent_tool_use_id.as_deref(),
+                    );
                 }
                 ToolEvent::Result(tr) => {
                     crate::display::tool_result(&tr.tool_use_id, !tr.is_error);

--- a/src/container_execution/process.rs
+++ b/src/container_execution/process.rs
@@ -63,8 +63,8 @@ fn stream_output(reader: BufReader<impl std::io::Read>, verbose: bool) -> Result
         for event in parser.last_tool_events() {
             match event {
                 ToolEvent::Use(tu) => {
-                    let args = format_tool_args(&tu.input);
-                    crate::display::tool_call(&tu.name, &args, &tu.id);
+                    let (display_name, args) = tool_display_label(&tu.name, &tu.input);
+                    crate::display::tool_call(&display_name, &args, &tu.id);
                 }
                 ToolEvent::Result(tr) => {
                     crate::display::tool_result(&tr.tool_use_id, !tr.is_error);
@@ -117,6 +117,23 @@ fn format_tool_args(input: &serde_json::Value) -> String {
         }
     }
     String::new()
+}
+
+fn tool_display_label(name: &str, input: &serde_json::Value) -> (String, String) {
+    if name == "Skill" {
+        let skill_name = input
+            .get("skill")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or("Skill")
+            .to_owned();
+        let args = input
+            .get("args")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or("")
+            .to_owned();
+        return (skill_name, args);
+    }
+    (name.to_owned(), format_tool_args(input))
 }
 
 /// Shared scaffolding for one container run: temp files, docker args, MCP config,
@@ -474,5 +491,36 @@ mod tests {
     fn format_tool_args_no_string_values_returns_empty() {
         let input = serde_json::json!({"a": 1, "b": true, "c": null});
         assert_eq!(format_tool_args(&input), "");
+    }
+
+    #[test]
+    fn skill_tool_uses_skill_field_as_display_name() {
+        let input = serde_json::json!({"skill": "tdd", "args": "some feature"});
+        let (name, args) = tool_display_label("Skill", &input);
+        assert_eq!(name, "tdd");
+        assert_eq!(args, "some feature");
+    }
+
+    #[test]
+    fn skill_tool_without_args_returns_empty_args() {
+        let input = serde_json::json!({"skill": "zoom-out"});
+        let (name, args) = tool_display_label("Skill", &input);
+        assert_eq!(name, "zoom-out");
+        assert_eq!(args, "");
+    }
+
+    #[test]
+    fn skill_tool_missing_skill_field_falls_back_to_skill_name() {
+        let input = serde_json::json!({});
+        let (name, _) = tool_display_label("Skill", &input);
+        assert_eq!(name, "Skill");
+    }
+
+    #[test]
+    fn non_skill_tool_uses_existing_format_tool_args_logic() {
+        let input = serde_json::json!({"command": "cargo test"});
+        let (name, args) = tool_display_label("Bash", &input);
+        assert_eq!(name, "Bash");
+        assert_eq!(args, "cargo test");
     }
 }

--- a/src/container_execution/stream_parser.rs
+++ b/src/container_execution/stream_parser.rs
@@ -5,6 +5,7 @@ pub struct ToolUseEvent {
     pub id: String,
     pub name: String,
     pub input: Value,
+    pub parent_tool_use_id: Option<String>,
 }
 
 pub struct ToolResultEvent {
@@ -219,6 +220,10 @@ fn extract_assistant_content(msg: &Value) -> (Vec<ToolEvent>, Vec<TextDisplay>) 
             let Some(content) = msg.pointer("/message/content").and_then(Value::as_array) else {
                 return (Vec::new(), Vec::new());
             };
+            let parent_tool_use_id = msg
+                .get("parent_tool_use_id")
+                .and_then(Value::as_str)
+                .map(str::to_owned);
             let mut tool_events = Vec::new();
             let mut text_displays = Vec::new();
             for block in content {
@@ -229,7 +234,12 @@ fn extract_assistant_content(msg: &Value) -> (Vec<ToolEvent>, Vec<TextDisplay>) 
                             block.get("id").and_then(Value::as_str).map(str::to_owned),
                             block.get("input").cloned(),
                         ) {
-                            tool_events.push(ToolEvent::Use(ToolUseEvent { id, name, input }));
+                            tool_events.push(ToolEvent::Use(ToolUseEvent {
+                                id,
+                                name,
+                                input,
+                                parent_tool_use_id: parent_tool_use_id.clone(),
+                            }));
                         }
                     }
                     Some("text") => {
@@ -1097,5 +1107,46 @@ mod tests {
     #[test]
     fn format_usage_with_percentage_zero_context_window() {
         assert_eq!(format_usage_with_percentage(1000, 0), "1.0k (0.0%) used");
+    }
+
+    #[test]
+    fn parent_tool_use_id_extracted_from_message_envelope() {
+        let line = r#"{"type":"assistant","parent_tool_use_id":"toolu_agent01","message":{"content":[{"type":"tool_use","id":"toolu_child01","name":"Bash","input":{"command":"ls"}}]}}"#;
+        let mut p = StreamParser::new();
+        p.feed(line);
+        let events = p.last_tool_events();
+        assert_eq!(events.len(), 1);
+        let ToolEvent::Use(tu) = &events[0] else {
+            panic!("expected ToolEvent::Use");
+        };
+        assert_eq!(tu.parent_tool_use_id.as_deref(), Some("toolu_agent01"));
+    }
+
+    #[test]
+    fn parent_tool_use_id_is_none_when_absent() {
+        let line = r#"{"type":"assistant","message":{"content":[{"type":"tool_use","id":"toolu_01","name":"Bash","input":{"command":"ls"}}]}}"#;
+        let mut p = StreamParser::new();
+        p.feed(line);
+        let events = p.last_tool_events();
+        assert_eq!(events.len(), 1);
+        let ToolEvent::Use(tu) = &events[0] else {
+            panic!("expected ToolEvent::Use");
+        };
+        assert!(tu.parent_tool_use_id.is_none());
+    }
+
+    #[test]
+    fn parent_tool_use_id_propagated_to_all_tool_uses_in_message() {
+        let line = r#"{"type":"assistant","parent_tool_use_id":"toolu_agent01","message":{"content":[{"type":"tool_use","id":"toolu_child01","name":"Bash","input":{"command":"ls"}},{"type":"tool_use","id":"toolu_child02","name":"Read","input":{"path":"/tmp/foo"}}]}}"#;
+        let mut p = StreamParser::new();
+        p.feed(line);
+        let events = p.last_tool_events();
+        assert_eq!(events.len(), 2);
+        for event in events {
+            let ToolEvent::Use(tu) = event else {
+                panic!("expected ToolEvent::Use");
+            };
+            assert_eq!(tu.parent_tool_use_id.as_deref(), Some("toolu_agent01"));
+        }
     }
 }

--- a/src/dev.rs
+++ b/src/dev.rs
@@ -20,7 +20,8 @@ pub fn log_docker_env(
     if !is_dev_build() {
         return;
     }
-    eprintln!("[dev] container: {container_name}");
+    eprintln!("[dev] container:");
+    eprintln!("[dev]   {container_name}");
     dump_file("env_file (.capsule/.env)", env_file);
     dump_file("extra_env_file (--env)", extra_env_file);
 }

--- a/src/display.rs
+++ b/src/display.rs
@@ -76,6 +76,7 @@ impl DisplayState {
 static STATE: OnceLock<Mutex<Option<DisplayState>>> = OnceLock::new();
 
 static LAST_WAS_TEXT: AtomicBool = AtomicBool::new(false);
+static LAST_TEXT_WAS_LIST_ITEM: AtomicBool = AtomicBool::new(false);
 static TIMER_GEN: AtomicU64 = AtomicU64::new(0);
 static PANIC_HOOK_SET: AtomicBool = AtomicBool::new(false);
 static TIMER_WAKE: OnceLock<(Mutex<()>, Condvar)> = OnceLock::new();
@@ -852,6 +853,14 @@ fn tool_result_to<W: Write + QueueableCommand>(
     out.flush()
 }
 
+fn is_list_item(s: &str) -> bool {
+    if s.starts_with("- ") || s.starts_with("* ") || s.starts_with("+ ") {
+        return true;
+    }
+    let rest = s.trim_start_matches(|c: char| c.is_ascii_digit());
+    rest.starts_with(". ") && rest.len() < s.len()
+}
+
 /// Print agent text (thinking or content) with a dot on the first
 /// line of each new block, and indented continuation lines within the same block.
 /// Text is wrapped at `content_width` so wrapped portions also get indented.
@@ -860,20 +869,26 @@ pub fn agent_text(text: &str) {
         return;
     }
     let mut last = LAST_WAS_TEXT.load(Ordering::Relaxed);
+    let last_list = LAST_TEXT_WAS_LIST_ITEM.load(Ordering::Relaxed);
     let was_text = last;
     let term_w = terminal_width() as usize;
     let content_width = term_w.min(MAX_DISPLAY_WIDTH).saturating_sub(2);
     let wrapped = wrap_text(text, content_width);
 
+    let is_list_cont =
+        !was_text && last_list && wrapped.first().map(|s| is_list_item(s)).unwrap_or(false);
+
     let mut out = stdout().lock();
-    agent_text_to(&mut out, &wrapped, &mut last).ok();
+    agent_text_to(&mut out, &wrapped, &mut last, last_list).ok();
     LAST_WAS_TEXT.store(last, Ordering::Relaxed);
+    let ends_list = wrapped.last().map(|s| is_list_item(s)).unwrap_or(false);
+    LAST_TEXT_WAS_LIST_ITEM.store(ends_list, Ordering::Relaxed);
     if LOG_FILE.get().is_some() {
-        if !was_text {
+        if !was_text && !is_list_cont {
             log_write("\n");
         }
         for (i, line) in wrapped.iter().enumerate() {
-            if i == 0 && !was_text {
+            if i == 0 && !was_text && !is_list_cont {
                 log_line(&format!("● {line}"));
             } else {
                 log_line(&format!("  {line}"));
@@ -883,7 +898,7 @@ pub fn agent_text(text: &str) {
 
     let mut guard = get_state().lock().unwrap_or_else(|e| e.into_inner());
     if let Some(state) = guard.as_mut() {
-        if !was_text {
+        if !was_text && !is_list_cont {
             state.offset_tracker.increment_all(1, state.term_width); // blank line
         }
         for line in &wrapped {
@@ -897,12 +912,16 @@ fn agent_text_to<W: Write + QueueableCommand>(
     out: &mut W,
     lines: &[String],
     last_was_text: &mut bool,
+    last_text_was_list: bool,
 ) -> std::io::Result<()> {
-    if !*last_was_text {
+    let is_list_cont = !*last_was_text
+        && last_text_was_list
+        && lines.first().map(|s| is_list_item(s)).unwrap_or(false);
+    if !*last_was_text && !is_list_cont {
         out.queue(Print("\n"))?;
     }
     for (i, line) in lines.iter().enumerate() {
-        if i == 0 && !*last_was_text {
+        if i == 0 && !*last_was_text && !is_list_cont {
             out.queue(Print("● "))?;
         } else {
             out.queue(Print("  "))?;
@@ -1452,7 +1471,7 @@ mod tests {
     fn agent_text_first_call_emits_dot_and_text() {
         let mut buf: Vec<u8> = Vec::new();
         let mut last = false;
-        agent_text_to(&mut buf, &["hello world".to_string()], &mut last).unwrap();
+        agent_text_to(&mut buf, &["hello world".to_string()], &mut last, false).unwrap();
         let out = String::from_utf8_lossy(&buf);
         assert!(out.contains("hello world"), "text must appear");
         assert!(out.contains('●'), "dot must appear on first line");
@@ -1463,7 +1482,7 @@ mod tests {
     fn agent_text_first_call_emits_blank_line_before_dot() {
         let mut buf: Vec<u8> = Vec::new();
         let mut last = false;
-        agent_text_to(&mut buf, &["hello".to_string()], &mut last).unwrap();
+        agent_text_to(&mut buf, &["hello".to_string()], &mut last, false).unwrap();
         let out = String::from_utf8_lossy(&buf);
         assert!(
             out.starts_with('\n'),
@@ -1475,7 +1494,7 @@ mod tests {
     fn agent_text_continuation_indents_without_dot() {
         let mut buf: Vec<u8> = Vec::new();
         let mut last = true;
-        agent_text_to(&mut buf, &["second line".to_string()], &mut last).unwrap();
+        agent_text_to(&mut buf, &["second line".to_string()], &mut last, false).unwrap();
         let out = String::from_utf8_lossy(&buf);
         assert!(out.contains("second line"), "text must appear");
         assert!(!out.contains('●'), "no dot on continuation line");
@@ -1489,7 +1508,7 @@ mod tests {
     fn agent_text_continuation_no_blank_line() {
         let mut buf: Vec<u8> = Vec::new();
         let mut last = true;
-        agent_text_to(&mut buf, &["continued".to_string()], &mut last).unwrap();
+        agent_text_to(&mut buf, &["continued".to_string()], &mut last, false).unwrap();
         let out = String::from_utf8_lossy(&buf);
         assert!(
             !out.starts_with('\n'),
@@ -1506,7 +1525,7 @@ mod tests {
             "second line".to_string(),
             "third line".to_string(),
         ];
-        agent_text_to(&mut buf, &lines, &mut last).unwrap();
+        agent_text_to(&mut buf, &lines, &mut last, false).unwrap();
         let out = String::from_utf8_lossy(&buf);
         let text_lines: Vec<&str> = out.lines().filter(|l| !l.is_empty()).collect();
         assert_eq!(text_lines.len(), 3);
@@ -1531,10 +1550,78 @@ mod tests {
     fn agent_text_body_not_dimmed() {
         let mut buf: Vec<u8> = Vec::new();
         let mut last = false;
-        agent_text_to(&mut buf, &["body text".to_string()], &mut last).unwrap();
+        agent_text_to(&mut buf, &["body text".to_string()], &mut last, false).unwrap();
         assert!(
             !buf.windows(4).any(|w| w == b"\x1b[2m"),
             "agent_text must not emit dim escape code on body text"
+        );
+    }
+
+    #[test]
+    fn is_list_item_detects_unordered() {
+        assert!(is_list_item("- item"));
+        assert!(is_list_item("* item"));
+        assert!(is_list_item("+ item"));
+        assert!(is_list_item("- "), "bare dash-space is a valid list marker");
+        assert!(!is_list_item("plain text"));
+        assert!(!is_list_item(""));
+    }
+
+    #[test]
+    fn is_list_item_detects_ordered() {
+        assert!(is_list_item("1. first"));
+        assert!(is_list_item("2. second"));
+        assert!(is_list_item("10. tenth"));
+        assert!(!is_list_item("no dot"));
+        assert!(!is_list_item(". no number"));
+    }
+
+    #[test]
+    fn list_continuation_skips_blank_line_and_dot() {
+        let mut buf: Vec<u8> = Vec::new();
+        let mut last = false; // simulate post-tool-call state
+        agent_text_to(&mut buf, &["2. second item".to_string()], &mut last, true).unwrap();
+        let out = String::from_utf8_lossy(&buf);
+        assert!(
+            !out.starts_with('\n'),
+            "list continuation must not emit a blank line"
+        );
+        assert!(!out.contains('●'), "list continuation must not emit a dot");
+        assert!(out.contains("2. second item"), "text must appear");
+    }
+
+    #[test]
+    fn list_start_after_non_list_emits_blank_line_and_dot() {
+        let mut buf: Vec<u8> = Vec::new();
+        let mut last = false; // post-tool-call state, but previous was NOT a list
+        agent_text_to(&mut buf, &["1. first item".to_string()], &mut last, false).unwrap();
+        let out = String::from_utf8_lossy(&buf);
+        assert!(
+            out.starts_with('\n'),
+            "new list section must start with a blank line"
+        );
+        assert!(out.contains('●'), "new list section must emit a dot");
+    }
+
+    #[test]
+    fn non_list_after_list_emits_blank_line_and_dot() {
+        let mut buf: Vec<u8> = Vec::new();
+        let mut last = false; // post-tool-call state, previous ended with list item
+        agent_text_to(
+            &mut buf,
+            &["Some paragraph text".to_string()],
+            &mut last,
+            true,
+        )
+        .unwrap();
+        let out = String::from_utf8_lossy(&buf);
+        assert!(
+            out.starts_with('\n'),
+            "non-list block after list must get a blank line"
+        );
+        assert!(
+            out.contains('●'),
+            "non-list block after list must get a dot"
         );
     }
 

--- a/src/display.rs
+++ b/src/display.rs
@@ -733,8 +733,9 @@ fn render_tty_tool_result_to<W: Write + QueueableCommand>(
             out.queue(Print(format!(" {name}  {args}\n")))?;
         }
     }
+    let pad = if depth > 0 { NESTING_PREFIX } else { "" };
     out.queue(Print(format!(
-        "  {label} ({:.1}s)\n",
+        "{pad}  {label} ({:.1}s)\n",
         duration.as_secs_f64()
     )))?;
     out.flush()
@@ -904,7 +905,10 @@ fn log_tool_result(name: &str, args: &str, duration: Duration, success: bool, de
     let status = if success { "Done" } else { "Failed" };
     let prefix = nesting_prefix(depth);
     log_line(&format!("{prefix}● {name}  {args}"));
-    log_line(&format!("  {status} ({:.1}s)", duration.as_secs_f64()));
+    log_line(&format!(
+        "{prefix}  {status} ({:.1}s)",
+        duration.as_secs_f64()
+    ));
 }
 
 fn tool_result_to<W: Write + QueueableCommand>(
@@ -924,8 +928,9 @@ fn tool_result_to<W: Write + QueueableCommand>(
     out.queue(Print("● "))?;
     out.queue(ResetColor)?;
     out.queue(Print(format!("{name}  {args}\n")))?;
+    let pad = if depth > 0 { NESTING_PREFIX } else { "" };
     out.queue(Print(format!(
-        "  {status} ({:.1}s)\n",
+        "{pad}  {status} ({:.1}s)\n",
         duration.as_secs_f64()
     )))?;
     out.flush()
@@ -1603,6 +1608,11 @@ mod tests {
         );
         assert!(out.contains("●"), "dot must still appear");
         assert!(out.contains("Read"), "tool name must appear");
+        let prefix_count = out.matches("├─").count();
+        assert_eq!(
+            prefix_count, 2,
+            "prefix must appear on both dot line and sub-line; output: {out:?}"
+        );
     }
 
     #[test]
@@ -2730,6 +2740,11 @@ mod tests {
         let prefix_pos = out.find("├─").expect("prefix must be present");
         let dot_pos = out.find('●').expect("dot must be present");
         assert!(prefix_pos < dot_pos, "prefix must appear before dot");
+        let prefix_count = out.matches("├─").count();
+        assert_eq!(
+            prefix_count, 2,
+            "prefix must appear on both dot line and sub-line; output: {out:?}"
+        );
     }
 
     #[test]

--- a/src/display.rs
+++ b/src/display.rs
@@ -29,6 +29,8 @@ struct ToolCallEntry {
     name: String,
     args: String,
     start_time: Instant,
+    #[allow(dead_code)]
+    parent_tool_use_id: Option<String>,
 }
 
 struct DisplayState {
@@ -709,7 +711,7 @@ fn render_tty_tool_result_to<W: Write + QueueableCommand>(
     out.flush()
 }
 
-pub fn tool_call(name: &str, args: &str, id: &str) {
+pub fn tool_call(name: &str, args: &str, id: &str, parent_tool_use_id: Option<&str>) {
     LAST_WAS_TEXT.store(false, Ordering::Relaxed);
 
     let display_args: String = if args.chars().count() > TOOL_ARGS_MAX {
@@ -738,6 +740,7 @@ pub fn tool_call(name: &str, args: &str, id: &str) {
                 name: name.to_owned(),
                 args: display_args.clone(),
                 start_time: Instant::now(),
+                parent_tool_use_id: parent_tool_use_id.map(str::to_owned),
             },
         ));
         drop(guard);
@@ -753,6 +756,7 @@ pub fn tool_call(name: &str, args: &str, id: &str) {
                     name: name.to_owned(),
                     args: display_args.clone(),
                     start_time: Instant::now(),
+                    parent_tool_use_id: parent_tool_use_id.map(str::to_owned),
                 },
             );
         tool_call_to(&mut out, name, &display_args).ok();

--- a/src/display.rs
+++ b/src/display.rs
@@ -29,8 +29,7 @@ struct ToolCallEntry {
     name: String,
     args: String,
     start_time: Instant,
-    #[allow(dead_code)]
-    parent_tool_use_id: Option<String>,
+    nesting_depth: u16,
 }
 
 struct DisplayState {
@@ -659,13 +658,29 @@ fn notice_box_to<W: Write + QueueableCommand>(
 }
 
 const TOOL_ARGS_MAX: usize = 60;
+const NESTING_PREFIX: &str = "├─ ";
+const NESTING_PREFIX_LEN: usize = 3;
+
+fn nesting_prefix(depth: u16) -> &'static str {
+    if depth > 0 {
+        NESTING_PREFIX
+    } else {
+        ""
+    }
+}
 
 fn render_tty_tool_call_to<W: Write + QueueableCommand>(
     out: &mut W,
     name: &str,
     display_args: &str,
+    depth: u16,
 ) -> std::io::Result<()> {
     out.queue(Print("\n"))?;
+    if depth > 0 {
+        out.queue(SetForegroundColor(Color::DarkGrey))?;
+        out.queue(Print(NESTING_PREFIX))?;
+        out.queue(ResetColor)?;
+    }
     out.queue(SetAttribute(Attribute::SlowBlink))?;
     out.queue(SetForegroundColor(Color::DarkGrey))?;
     out.queue(Print("●"))?;
@@ -681,9 +696,11 @@ fn render_tty_tool_result_to<W: Write + QueueableCommand>(
     duration: Duration,
     success: bool,
     offset: Option<u16>,
+    depth: u16,
 ) -> std::io::Result<()> {
     let color = if success { GREEN } else { RED };
     let label = if success { "Done" } else { "Failed" };
+    let prefix = nesting_prefix(depth);
 
     match offset {
         Some(n) => {
@@ -691,6 +708,11 @@ fn render_tty_tool_result_to<W: Write + QueueableCommand>(
             out.queue(cursor::MoveUp(n))?;
             out.queue(cursor::MoveToColumn(0))?;
             out.queue(terminal::Clear(ClearType::CurrentLine))?;
+            if depth > 0 {
+                out.queue(SetForegroundColor(Color::DarkGrey))?;
+                out.queue(Print(prefix))?;
+                out.queue(ResetColor)?;
+            }
             out.queue(SetForegroundColor(color))?;
             out.queue(Print("●"))?;
             out.queue(ResetColor)?;
@@ -698,6 +720,11 @@ fn render_tty_tool_result_to<W: Write + QueueableCommand>(
             out.queue(cursor::RestorePosition)?;
         }
         None => {
+            if depth > 0 {
+                out.queue(SetForegroundColor(Color::DarkGrey))?;
+                out.queue(Print(prefix))?;
+                out.queue(ResetColor)?;
+            }
             out.queue(SetForegroundColor(color))?;
             out.queue(Print("●"))?;
             out.queue(ResetColor)?;
@@ -720,14 +747,25 @@ pub fn tool_call(name: &str, args: &str, id: &str, parent_tool_use_id: Option<&s
     } else {
         args.to_owned()
     };
-    log_line(&format!("\n● {name}  {display_args}"));
 
     let mut out = stdout().lock();
     let mut guard = get_state().lock().unwrap_or_else(|e| e.into_inner());
     handle_resize_if_needed(&mut guard, &mut out);
     if let Some(state) = guard.as_mut() {
+        let nesting_depth = parent_tool_use_id
+            .and_then(|pid| state.active_tool_calls.iter().find(|(eid, _)| eid == pid))
+            .map(|(_, e)| e.nesting_depth + 1)
+            .unwrap_or(0);
+        let prefix_len = if nesting_depth > 0 {
+            NESTING_PREFIX_LEN
+        } else {
+            0
+        };
+        let prefix = nesting_prefix(nesting_depth);
+        log_line(&format!("\n{prefix}● {name}  {display_args}"));
         state.offset_tracker.increment_all(1, state.term_width); // blank line
-        let visible_width = 2 + name.chars().count() + 2 + display_args.chars().count();
+        let visible_width =
+            prefix_len + 2 + name.chars().count() + 2 + display_args.chars().count();
         state
             .offset_tracker
             .increment_all(visible_width, state.term_width);
@@ -740,13 +778,22 @@ pub fn tool_call(name: &str, args: &str, id: &str, parent_tool_use_id: Option<&s
                 name: name.to_owned(),
                 args: display_args.clone(),
                 start_time: Instant::now(),
-                parent_tool_use_id: parent_tool_use_id.map(str::to_owned),
+                nesting_depth,
             },
         ));
         drop(guard);
-        render_tty_tool_call_to(&mut out, name, &display_args).ok();
+        render_tty_tool_call_to(&mut out, name, &display_args, nesting_depth).ok();
     } else {
         drop(guard);
+        let nesting_depth = {
+            let cache = tool_call_cache().lock().unwrap_or_else(|e| e.into_inner());
+            parent_tool_use_id
+                .and_then(|pid| cache.get(pid))
+                .map(|e| e.nesting_depth + 1)
+                .unwrap_or(0)
+        };
+        let prefix = nesting_prefix(nesting_depth);
+        log_line(&format!("\n{prefix}● {name}  {display_args}"));
         tool_call_cache()
             .lock()
             .unwrap_or_else(|e| e.into_inner())
@@ -756,10 +803,10 @@ pub fn tool_call(name: &str, args: &str, id: &str, parent_tool_use_id: Option<&s
                     name: name.to_owned(),
                     args: display_args.clone(),
                     start_time: Instant::now(),
-                    parent_tool_use_id: parent_tool_use_id.map(str::to_owned),
+                    nesting_depth,
                 },
             );
-        tool_call_to(&mut out, name, &display_args).ok();
+        tool_call_to(&mut out, name, &display_args, nesting_depth).ok();
     }
 }
 
@@ -767,8 +814,12 @@ fn tool_call_to<W: Write + QueueableCommand>(
     out: &mut W,
     name: &str,
     display_args: &str,
+    depth: u16,
 ) -> std::io::Result<()> {
     out.queue(Print("\n"))?;
+    if depth > 0 {
+        out.queue(Print(NESTING_PREFIX))?;
+    }
     out.queue(SetForegroundColor(YELLOW))?;
     out.queue(Print("● "))?;
     out.queue(ResetColor)?;
@@ -788,9 +839,9 @@ pub fn tool_result(id: &str, success: bool) {
             .iter()
             .position(|(eid, _)| eid == id);
         let entry = entry_pos.map(|i| state.active_tool_calls.remove(i));
-        let (name, args, duration) = match entry {
-            Some((_, e)) => (e.name, e.args, e.start_time.elapsed()),
-            None => ("unknown".to_owned(), String::new(), Duration::ZERO),
+        let (name, args, duration, nesting_depth) = match entry {
+            Some((_, e)) => (e.name, e.args, e.start_time.elapsed(), e.nesting_depth),
+            None => ("unknown".to_owned(), String::new(), Duration::ZERO, 0),
         };
         let scroll_height = state.separator_row();
         let offset = state.offset_tracker.get_offset(id, scroll_height);
@@ -798,8 +849,17 @@ pub fn tool_result(id: &str, success: bool) {
         let tw = state.term_width;
         drop(guard);
 
-        render_tty_tool_result_to(&mut out, &name, &args, duration, success, offset).ok();
-        log_tool_result(&name, &args, duration, success);
+        render_tty_tool_result_to(
+            &mut out,
+            &name,
+            &args,
+            duration,
+            success,
+            offset,
+            nesting_depth,
+        )
+        .ok();
+        log_tool_result(&name, &args, duration, success, nesting_depth);
 
         // Account for the sub-line (and the solid-dot line in the off-screen case).
         let label = if success { "Done" } else { "Failed" };
@@ -810,7 +870,13 @@ pub fn tool_result(id: &str, success: bool) {
         if let Some(state) = guard.as_mut() {
             if offset.is_none() {
                 // Off-screen path wrote 2 lines: solid dot + sub-line.
-                let line1_visible = 2 + name.chars().count() + 2 + args.chars().count();
+                let prefix_len = if nesting_depth > 0 {
+                    NESTING_PREFIX_LEN
+                } else {
+                    0
+                };
+                let line1_visible =
+                    prefix_len + 2 + name.chars().count() + 2 + args.chars().count();
                 state.offset_tracker.increment_all(line1_visible, tw);
             }
             state.offset_tracker.increment_all(sub_visible, tw);
@@ -821,18 +887,19 @@ pub fn tool_result(id: &str, success: bool) {
             .lock()
             .unwrap_or_else(|e| e.into_inner())
             .remove(id);
-        let (name, args, duration) = match info {
-            Some(i) => (i.name, i.args, i.start_time.elapsed()),
-            None => ("unknown".to_owned(), String::new(), Duration::ZERO),
+        let (name, args, duration, nesting_depth) = match info {
+            Some(i) => (i.name, i.args, i.start_time.elapsed(), i.nesting_depth),
+            None => ("unknown".to_owned(), String::new(), Duration::ZERO, 0),
         };
-        tool_result_to(&mut out, &name, &args, duration, success).ok();
-        log_tool_result(&name, &args, duration, success);
+        tool_result_to(&mut out, &name, &args, duration, success, nesting_depth).ok();
+        log_tool_result(&name, &args, duration, success, nesting_depth);
     }
 }
 
-fn log_tool_result(name: &str, args: &str, duration: Duration, success: bool) {
+fn log_tool_result(name: &str, args: &str, duration: Duration, success: bool, depth: u16) {
     let status = if success { "Done" } else { "Failed" };
-    log_line(&format!("● {name}  {args}"));
+    let prefix = nesting_prefix(depth);
+    log_line(&format!("{prefix}● {name}  {args}"));
     log_line(&format!("  {status} ({:.1}s)", duration.as_secs_f64()));
 }
 
@@ -842,9 +909,13 @@ fn tool_result_to<W: Write + QueueableCommand>(
     args: &str,
     duration: Duration,
     success: bool,
+    depth: u16,
 ) -> std::io::Result<()> {
     let color = if success { GREEN } else { RED };
     let status = if success { "Done" } else { "Failed" };
+    if depth > 0 {
+        out.queue(Print(NESTING_PREFIX))?;
+    }
     out.queue(SetForegroundColor(color))?;
     out.queue(Print("● "))?;
     out.queue(ResetColor)?;
@@ -1371,7 +1442,7 @@ mod tests {
     #[test]
     fn tool_call_renders_name_and_args() {
         let mut buf: Vec<u8> = Vec::new();
-        tool_call_to(&mut buf, "Bash", "ls -la").unwrap();
+        tool_call_to(&mut buf, "Bash", "ls -la", 0).unwrap();
         let out = String::from_utf8_lossy(&buf);
         assert!(out.contains("Bash"), "tool name must appear in output");
         assert!(out.contains("ls -la"), "args must appear in output");
@@ -1384,7 +1455,7 @@ mod tests {
         let truncated: String = long_args.chars().take(TOOL_ARGS_MAX).collect();
         let display_args = format!("{truncated}…");
         let mut buf: Vec<u8> = Vec::new();
-        tool_call_to(&mut buf, "Bash", &display_args).unwrap();
+        tool_call_to(&mut buf, "Bash", &display_args, 0).unwrap();
         let out = String::from_utf8_lossy(&buf);
         assert!(out.contains("…"), "truncated args must end with ellipsis");
         assert!(
@@ -1397,16 +1468,45 @@ mod tests {
     fn tool_call_short_args_not_truncated() {
         let short_args = "short";
         let mut buf: Vec<u8> = Vec::new();
-        tool_call_to(&mut buf, "Read", short_args).unwrap();
+        tool_call_to(&mut buf, "Read", short_args, 0).unwrap();
         let out = String::from_utf8_lossy(&buf);
         assert!(out.contains(short_args), "short args must appear verbatim");
         assert!(!out.contains("…"), "short args must not be truncated");
     }
 
     #[test]
+    fn tool_call_depth_zero_no_prefix() {
+        let mut buf: Vec<u8> = Vec::new();
+        tool_call_to(&mut buf, "Bash", "ls", 0).unwrap();
+        let out = String::from_utf8_lossy(&buf);
+        assert!(
+            !out.contains("├"),
+            "depth-0 call must not emit nesting prefix"
+        );
+    }
+
+    #[test]
+    fn tool_call_depth_nonzero_emits_prefix() {
+        let mut buf: Vec<u8> = Vec::new();
+        tool_call_to(&mut buf, "Bash", "ls", 1).unwrap();
+        let out = String::from_utf8_lossy(&buf);
+        assert!(out.contains("├─"), "depth-1 call must emit nesting prefix");
+        assert!(out.contains("●"), "dot must still appear after prefix");
+        assert!(out.contains("Bash"), "tool name must appear");
+    }
+
+    #[test]
     fn tool_result_non_tty_no_cursor_up_emits_green_dot() {
         let mut buf: Vec<u8> = Vec::new();
-        tool_result_to(&mut buf, "Bash", "ls -la", Duration::from_millis(123), true).unwrap();
+        tool_result_to(
+            &mut buf,
+            "Bash",
+            "ls -la",
+            Duration::from_millis(123),
+            true,
+            0,
+        )
+        .unwrap();
         let out = String::from_utf8_lossy(&buf);
         assert!(
             !buf.windows(4).any(|w| w == b"\x1b[1A"),
@@ -1432,6 +1532,7 @@ mod tests {
             "path/to/file",
             Duration::from_millis(456),
             false,
+            0,
         )
         .unwrap();
         let out = String::from_utf8_lossy(&buf);
@@ -1450,6 +1551,35 @@ mod tests {
             contains_seq(&buf, RED_ANSI),
             "red escape must be emitted for failure; output: {out:?}"
         );
+    }
+
+    #[test]
+    fn tool_result_non_tty_depth_zero_no_prefix() {
+        let mut buf: Vec<u8> = Vec::new();
+        tool_result_to(&mut buf, "Bash", "ls", Duration::from_millis(100), true, 0).unwrap();
+        let out = String::from_utf8_lossy(&buf);
+        assert!(!out.contains("├"), "depth-0 result must not emit prefix");
+    }
+
+    #[test]
+    fn tool_result_non_tty_depth_nonzero_emits_prefix() {
+        let mut buf: Vec<u8> = Vec::new();
+        tool_result_to(
+            &mut buf,
+            "Read",
+            "file.rs",
+            Duration::from_millis(50),
+            true,
+            1,
+        )
+        .unwrap();
+        let out = String::from_utf8_lossy(&buf);
+        assert!(
+            out.contains("├─"),
+            "depth-1 result must emit nesting prefix"
+        );
+        assert!(out.contains("●"), "dot must still appear");
+        assert!(out.contains("Read"), "tool name must appear");
     }
 
     #[test]
@@ -2238,7 +2368,7 @@ mod tests {
     #[test]
     fn tty_tool_call_emits_slow_blink_and_dark_grey_dot() {
         let mut buf: Vec<u8> = Vec::new();
-        render_tty_tool_call_to(&mut buf, "Bash", "ls -la").unwrap();
+        render_tty_tool_call_to(&mut buf, "Bash", "ls -la", 0).unwrap();
         let out = String::from_utf8_lossy(&buf);
         assert!(
             contains_seq(&buf, BLINK_ANSI),
@@ -2257,7 +2387,7 @@ mod tests {
     #[test]
     fn tty_tool_call_includes_name_and_args() {
         let mut buf: Vec<u8> = Vec::new();
-        render_tty_tool_call_to(&mut buf, "Read", "src/main.rs").unwrap();
+        render_tty_tool_call_to(&mut buf, "Read", "src/main.rs", 0).unwrap();
         let out = String::from_utf8_lossy(&buf);
         assert!(
             out.contains("Read"),
@@ -2271,6 +2401,28 @@ mod tests {
     }
 
     #[test]
+    fn tty_tool_call_depth_zero_no_prefix() {
+        let mut buf: Vec<u8> = Vec::new();
+        render_tty_tool_call_to(&mut buf, "Bash", "ls", 0).unwrap();
+        let out = String::from_utf8_lossy(&buf);
+        assert!(!out.contains("├"), "depth-0 TTY call must not emit prefix");
+    }
+
+    #[test]
+    fn tty_tool_call_depth_nonzero_emits_prefix_before_dot() {
+        let mut buf: Vec<u8> = Vec::new();
+        render_tty_tool_call_to(&mut buf, "Read", "file.rs", 1).unwrap();
+        let out = String::from_utf8_lossy(&buf);
+        assert!(
+            out.contains("├─"),
+            "depth-1 TTY call must emit prefix; output: {out:?}"
+        );
+        let prefix_pos = out.find("├─").expect("prefix must be present");
+        let dot_pos = out.find('●').expect("dot must be present");
+        assert!(prefix_pos < dot_pos, "prefix must appear before dot");
+    }
+
+    #[test]
     fn tty_tool_result_in_place_emits_cursor_up() {
         let mut buf: Vec<u8> = Vec::new();
         render_tty_tool_result_to(
@@ -2280,6 +2432,7 @@ mod tests {
             Duration::from_millis(200),
             true,
             Some(3),
+            0,
         )
         .unwrap();
         let out = String::from_utf8_lossy(&buf);
@@ -2300,6 +2453,7 @@ mod tests {
             Duration::from_millis(200),
             true,
             Some(2),
+            0,
         )
         .unwrap();
         let out = String::from_utf8_lossy(&buf);
@@ -2327,6 +2481,7 @@ mod tests {
             Duration::from_millis(300),
             false,
             Some(1),
+            0,
         )
         .unwrap();
         let out = String::from_utf8_lossy(&buf);
@@ -2350,6 +2505,7 @@ mod tests {
             Duration::from_millis(100),
             true,
             None,
+            0,
         )
         .unwrap();
         let out = String::from_utf8_lossy(&buf);
@@ -2379,6 +2535,7 @@ mod tests {
             Duration::from_millis(450),
             true,
             None,
+            0,
         )
         .unwrap();
         let out = String::from_utf8_lossy(&buf);
@@ -2412,6 +2569,7 @@ mod tests {
             Duration::from_millis(50),
             true,
             Some(5),
+            0,
         )
         .unwrap();
         let out = String::from_utf8_lossy(&buf);
@@ -2419,5 +2577,45 @@ mod tests {
             out.contains("my/special/path.rs"),
             "args must be preserved in the in-place updated line; output: {out:?}"
         );
+    }
+
+    #[test]
+    fn tty_tool_result_depth_nonzero_emits_prefix_off_screen() {
+        let mut buf: Vec<u8> = Vec::new();
+        render_tty_tool_result_to(
+            &mut buf,
+            "Read",
+            "file.rs",
+            Duration::from_millis(100),
+            true,
+            None,
+            1,
+        )
+        .unwrap();
+        let out = String::from_utf8_lossy(&buf);
+        assert!(
+            out.contains("├─"),
+            "depth-1 off-screen result must emit prefix; output: {out:?}"
+        );
+        let prefix_pos = out.find("├─").expect("prefix must be present");
+        let dot_pos = out.find('●').expect("dot must be present");
+        assert!(prefix_pos < dot_pos, "prefix must appear before dot");
+    }
+
+    #[test]
+    fn tty_tool_result_depth_zero_off_screen_no_prefix() {
+        let mut buf: Vec<u8> = Vec::new();
+        render_tty_tool_result_to(
+            &mut buf,
+            "Read",
+            "file.rs",
+            Duration::from_millis(100),
+            true,
+            None,
+            0,
+        )
+        .unwrap();
+        let out = String::from_utf8_lossy(&buf);
+        assert!(!out.contains("├"), "depth-0 result must not emit prefix");
     }
 }

--- a/src/display.rs
+++ b/src/display.rs
@@ -669,7 +669,8 @@ fn nesting_prefix(depth: u16) -> String {
         0 => String::new(),
         1 => NESTING_BRANCH.to_owned(),
         d => {
-            let mut s = String::with_capacity(NESTING_SEGMENT_LEN * d as usize);
+            let mut s =
+                String::with_capacity(NESTING_PIPE.len() * (d as usize - 1) + NESTING_BRANCH.len());
             for _ in 0..d - 1 {
                 s.push_str(NESTING_PIPE);
             }
@@ -874,9 +875,10 @@ pub fn tool_result(id: &str, success: bool) {
 
         // Account for the sub-line (and the solid-dot line in the off-screen case).
         let label = if success { "Done" } else { "Failed" };
-        let sub_visible = format!("  {label} ({:.1}s)", duration.as_secs_f64())
-            .chars()
-            .count();
+        let sub_visible = nesting_prefix_len(nesting_depth)
+            + format!("  {label} ({:.1}s)", duration.as_secs_f64())
+                .chars()
+                .count();
         let mut guard = get_state().lock().unwrap_or_else(|e| e.into_inner());
         if let Some(state) = guard.as_mut() {
             if offset.is_none() {

--- a/src/display.rs
+++ b/src/display.rs
@@ -660,15 +660,27 @@ fn notice_box_to<W: Write + QueueableCommand>(
 }
 
 const TOOL_ARGS_MAX: usize = 60;
-const NESTING_PREFIX: &str = "├─ ";
-const NESTING_PREFIX_LEN: usize = 3;
+const NESTING_BRANCH: &str = "├─ ";
+const NESTING_PIPE: &str = "│  ";
+const NESTING_SEGMENT_LEN: usize = 3;
 
-fn nesting_prefix(depth: u16) -> &'static str {
-    if depth > 0 {
-        NESTING_PREFIX
-    } else {
-        ""
+fn nesting_prefix(depth: u16) -> String {
+    match depth {
+        0 => String::new(),
+        1 => NESTING_BRANCH.to_owned(),
+        d => {
+            let mut s = String::with_capacity(NESTING_SEGMENT_LEN * d as usize);
+            for _ in 0..d - 1 {
+                s.push_str(NESTING_PIPE);
+            }
+            s.push_str(NESTING_BRANCH);
+            s
+        }
     }
+}
+
+fn nesting_prefix_len(depth: u16) -> usize {
+    NESTING_SEGMENT_LEN * depth as usize
 }
 
 fn render_tty_tool_call_to<W: Write + QueueableCommand>(
@@ -679,8 +691,9 @@ fn render_tty_tool_call_to<W: Write + QueueableCommand>(
 ) -> std::io::Result<()> {
     out.queue(Print("\n"))?;
     if depth > 0 {
+        let prefix = nesting_prefix(depth);
         out.queue(SetForegroundColor(Color::DarkGrey))?;
-        out.queue(Print(NESTING_PREFIX))?;
+        out.queue(Print(prefix))?;
         out.queue(ResetColor)?;
     }
     out.queue(SetAttribute(Attribute::SlowBlink))?;
@@ -712,7 +725,7 @@ fn render_tty_tool_result_to<W: Write + QueueableCommand>(
             out.queue(terminal::Clear(ClearType::CurrentLine))?;
             if depth > 0 {
                 out.queue(SetForegroundColor(Color::DarkGrey))?;
-                out.queue(Print(prefix))?;
+                out.queue(Print(&prefix))?;
                 out.queue(ResetColor)?;
             }
             out.queue(SetForegroundColor(color))?;
@@ -724,7 +737,7 @@ fn render_tty_tool_result_to<W: Write + QueueableCommand>(
         None => {
             if depth > 0 {
                 out.queue(SetForegroundColor(Color::DarkGrey))?;
-                out.queue(Print(prefix))?;
+                out.queue(Print(&prefix))?;
                 out.queue(ResetColor)?;
             }
             out.queue(SetForegroundColor(color))?;
@@ -733,9 +746,8 @@ fn render_tty_tool_result_to<W: Write + QueueableCommand>(
             out.queue(Print(format!(" {name}  {args}\n")))?;
         }
     }
-    let pad = if depth > 0 { NESTING_PREFIX } else { "" };
     out.queue(Print(format!(
-        "{pad}  {label} ({:.1}s)\n",
+        "{prefix}  {label} ({:.1}s)\n",
         duration.as_secs_f64()
     )))?;
     out.flush()
@@ -759,16 +771,11 @@ pub fn tool_call(name: &str, args: &str, id: &str, parent_tool_use_id: Option<&s
             .and_then(|pid| state.active_tool_calls.iter().find(|(eid, _)| eid == pid))
             .map(|(_, e)| e.nesting_depth + 1)
             .unwrap_or(0);
-        let prefix_len = if nesting_depth > 0 {
-            NESTING_PREFIX_LEN
-        } else {
-            0
-        };
         let prefix = nesting_prefix(nesting_depth);
+        let plen = nesting_prefix_len(nesting_depth);
         log_line(&format!("\n{prefix}● {name}  {display_args}"));
         state.offset_tracker.increment_all(1, state.term_width);
-        let visible_width =
-            prefix_len + 2 + name.chars().count() + 2 + display_args.chars().count();
+        let visible_width = plen + 2 + name.chars().count() + 2 + display_args.chars().count();
         state
             .offset_tracker
             .increment_all(visible_width, state.term_width);
@@ -821,7 +828,7 @@ fn tool_call_to<W: Write + QueueableCommand>(
 ) -> std::io::Result<()> {
     out.queue(Print("\n"))?;
     if depth > 0 {
-        out.queue(Print(NESTING_PREFIX))?;
+        out.queue(Print(nesting_prefix(depth)))?;
     }
     out.queue(SetForegroundColor(YELLOW))?;
     out.queue(Print("● "))?;
@@ -874,13 +881,8 @@ pub fn tool_result(id: &str, success: bool) {
         if let Some(state) = guard.as_mut() {
             if offset.is_none() {
                 // Off-screen path wrote 2 lines: solid dot + sub-line.
-                let prefix_len = if nesting_depth > 0 {
-                    NESTING_PREFIX_LEN
-                } else {
-                    0
-                };
-                let line1_visible =
-                    prefix_len + 2 + name.chars().count() + 2 + args.chars().count();
+                let plen = nesting_prefix_len(nesting_depth);
+                let line1_visible = plen + 2 + name.chars().count() + 2 + args.chars().count();
                 state.offset_tracker.increment_all(line1_visible, tw);
             }
             state.offset_tracker.increment_all(sub_visible, tw);
@@ -921,16 +923,16 @@ fn tool_result_to<W: Write + QueueableCommand>(
 ) -> std::io::Result<()> {
     let color = if success { GREEN } else { RED };
     let status = if success { "Done" } else { "Failed" };
+    let prefix = nesting_prefix(depth);
     if depth > 0 {
-        out.queue(Print(NESTING_PREFIX))?;
+        out.queue(Print(&prefix))?;
     }
     out.queue(SetForegroundColor(color))?;
     out.queue(Print("● "))?;
     out.queue(ResetColor)?;
     out.queue(Print(format!("{name}  {args}\n")))?;
-    let pad = if depth > 0 { NESTING_PREFIX } else { "" };
     out.queue(Print(format!(
-        "{pad}  {status} ({:.1}s)\n",
+        "{prefix}  {status} ({:.1}s)\n",
         duration.as_secs_f64()
     )))?;
     out.flush()
@@ -1503,6 +1505,30 @@ mod tests {
     }
 
     #[test]
+    fn nesting_prefix_depth_0_is_empty() {
+        assert_eq!(nesting_prefix(0), "");
+        assert_eq!(nesting_prefix_len(0), 0);
+    }
+
+    #[test]
+    fn nesting_prefix_depth_1_is_branch_only() {
+        assert_eq!(nesting_prefix(1), "├─ ");
+        assert_eq!(nesting_prefix_len(1), 3);
+    }
+
+    #[test]
+    fn nesting_prefix_depth_2_is_pipe_then_branch() {
+        assert_eq!(nesting_prefix(2), "│  ├─ ");
+        assert_eq!(nesting_prefix_len(2), 6);
+    }
+
+    #[test]
+    fn nesting_prefix_depth_3_has_two_pipes() {
+        assert_eq!(nesting_prefix(3), "│  │  ├─ ");
+        assert_eq!(nesting_prefix_len(3), 9);
+    }
+
+    #[test]
     fn tool_call_depth_zero_no_prefix() {
         let mut buf: Vec<u8> = Vec::new();
         tool_call_to(&mut buf, "Bash", "ls", 0).unwrap();
@@ -1521,6 +1547,21 @@ mod tests {
         assert!(out.contains("├─"), "depth-1 call must emit nesting prefix");
         assert!(out.contains("●"), "dot must still appear after prefix");
         assert!(out.contains("Bash"), "tool name must appear");
+    }
+
+    #[test]
+    fn tool_call_depth_2_emits_pipe_then_branch() {
+        let mut buf: Vec<u8> = Vec::new();
+        tool_call_to(&mut buf, "Bash", "ls", 2).unwrap();
+        let out = String::from_utf8_lossy(&buf);
+        assert!(out.contains("│"), "depth-2 must include pipe segment");
+        assert!(out.contains("├─"), "depth-2 must include branch segment");
+        let pipe_pos = out.find('│').unwrap();
+        let branch_pos = out.find("├─").unwrap();
+        assert!(
+            pipe_pos < branch_pos,
+            "pipe must appear before branch; output: {out:?}"
+        );
     }
 
     #[test]

--- a/src/display.rs
+++ b/src/display.rs
@@ -490,6 +490,7 @@ fn render_box<W: Write + QueueableCommand>(
 /// ```
 pub fn stage_header(stage_name: &str, iteration: u32, model: &str, retry: Option<&RetryInfo>) {
     LAST_WAS_TEXT.store(false, Ordering::Relaxed);
+    LAST_TEXT_WAS_LIST_ITEM.store(false, Ordering::Relaxed);
     let term_w = terminal_width() as usize;
     let mut out = stdout().lock();
     render_stage_header_to(&mut out, stage_name, iteration, model, retry, term_w).ok();
@@ -1007,6 +1008,7 @@ pub fn session_footer(
     context_usage: Option<&str>,
 ) {
     LAST_WAS_TEXT.store(false, Ordering::Relaxed);
+    LAST_TEXT_WAS_LIST_ITEM.store(false, Ordering::Relaxed);
     let ts = local_timestamp();
     session_footer_to(
         &mut stdout().lock(),

--- a/src/display.rs
+++ b/src/display.rs
@@ -763,7 +763,7 @@ pub fn tool_call(name: &str, args: &str, id: &str, parent_tool_use_id: Option<&s
         };
         let prefix = nesting_prefix(nesting_depth);
         log_line(&format!("\n{prefix}● {name}  {display_args}"));
-        state.offset_tracker.increment_all(1, state.term_width); // blank line
+        state.offset_tracker.increment_all(1, state.term_width);
         let visible_width =
             prefix_len + 2 + name.chars().count() + 2 + display_args.chars().count();
         state
@@ -959,7 +959,7 @@ pub fn agent_text(text: &str) {
     let mut guard = get_state().lock().unwrap_or_else(|e| e.into_inner());
     if let Some(state) = guard.as_mut() {
         if !was_text {
-            state.offset_tracker.increment_all(1, state.term_width); // blank line
+            state.offset_tracker.increment_all(1, state.term_width);
         }
         for line in &wrapped {
             let vw = 2 + line.chars().count();

--- a/src/display.rs
+++ b/src/display.rs
@@ -786,10 +786,11 @@ pub fn tool_result(id: &str, success: bool) {
             .iter()
             .position(|(eid, _)| eid == id);
         let entry = entry_pos.map(|i| state.active_tool_calls.remove(i));
-        let (name, args, duration) = match entry {
-            Some((_, e)) => (e.name, e.args, e.start_time.elapsed()),
-            None => ("unknown".to_owned(), String::new(), Duration::ZERO),
+        let Some((_, e)) = entry else {
+            // Duplicate or unknown tool_use_id — skip to avoid a spurious Done line.
+            return;
         };
+        let (name, args, duration) = (e.name, e.args, e.start_time.elapsed());
         let scroll_height = state.separator_row();
         let offset = state.offset_tracker.get_offset(id, scroll_height);
         state.offset_tracker.remove(id);
@@ -819,10 +820,11 @@ pub fn tool_result(id: &str, success: bool) {
             .lock()
             .unwrap_or_else(|e| e.into_inner())
             .remove(id);
-        let (name, args, duration) = match info {
-            Some(i) => (i.name, i.args, i.start_time.elapsed()),
-            None => ("unknown".to_owned(), String::new(), Duration::ZERO),
+        let Some(i) = info else {
+            // Duplicate or unknown tool_use_id — skip to avoid a spurious Done line.
+            return;
         };
+        let (name, args, duration) = (i.name, i.args, i.start_time.elapsed());
         tool_result_to(&mut out, &name, &args, duration, success).ok();
         log_tool_result(&name, &args, duration, success);
     }
@@ -2503,6 +2505,75 @@ mod tests {
         assert!(
             out.contains("my/special/path.rs"),
             "args must be preserved in the in-place updated line; output: {out:?}"
+        );
+    }
+
+    #[test]
+    fn tool_result_to_renders_done_line() {
+        let mut buf: Vec<u8> = Vec::new();
+        tool_result_to(&mut buf, "Bash", "ls", Duration::from_millis(300), true).unwrap();
+        let out = String::from_utf8_lossy(&buf);
+        assert!(out.contains("Done"), "must contain Done; output: {out:?}");
+        assert!(
+            out.contains("0.3s"),
+            "must contain duration; output: {out:?}"
+        );
+        assert!(
+            out.contains("Bash"),
+            "must contain tool name; output: {out:?}"
+        );
+    }
+
+    #[test]
+    fn tool_result_to_renders_failed_line() {
+        let mut buf: Vec<u8> = Vec::new();
+        tool_result_to(
+            &mut buf,
+            "Bash",
+            "rm -rf",
+            Duration::from_millis(100),
+            false,
+        )
+        .unwrap();
+        let out = String::from_utf8_lossy(&buf);
+        assert!(
+            out.contains("Failed"),
+            "must contain Failed; output: {out:?}"
+        );
+        assert!(
+            contains_seq(&buf, RED_ANSI),
+            "must use red for failure; output: {out:?}"
+        );
+    }
+
+    #[test]
+    fn tool_call_cache_dedup_second_remove_returns_none() {
+        let id = "dedup_test_unique_id_9f3a";
+        tool_call_cache()
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .insert(
+                id.to_owned(),
+                ToolCallEntry {
+                    name: "TestTool".to_owned(),
+                    args: "some_arg".to_owned(),
+                    start_time: Instant::now(),
+                },
+            );
+
+        let first = tool_call_cache()
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .remove(id);
+        assert!(first.is_some(), "first removal must return the entry");
+
+        let second = tool_call_cache()
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .remove(id);
+        assert!(
+            second.is_none(),
+            "second removal must return None — duplicate result must be dropped"
         );
     }
 }


### PR DESCRIPTION
## Parent
Closes #247

## Summary
Fixes five output formatting issues: standardizes [dev] line indentation, shows skill names instead of raw arguments in tool call logs, suppresses extra blank lines between list items across tool calls, resets list-item state at stage/session boundaries, and deduplicates Done lines for repeated tool_use_ids.

## Notes
All changes are in display/process layers — no behavioral changes to pipeline logic.