### PR TITLE
feat: support docker.volumes in config.yml for custom container mounts

### DIFF
--- a/.capsule/config.yml
+++ b/.capsule/config.yml
@@ -20,6 +20,9 @@ stages:
       prompt: prompts/documentor.md
 
 model: claude-opus-4-6
+docker:
+  volumes:
+    - ".cargo-cache:/home/claude/.cargo/registry"
 github_token_from: local
 commit_as: capsule
 setup: ": \"${PARENT:?PARENT is required}\" && echo \"working on: #${PARENT}\""

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *~
 /target/
 /.cargo/
+/.cargo-cache/
 .capsule/.env
 .capsule*/last-run.json
 .claude/settings.local.json

--- a/schema/config.schema.json
+++ b/schema/config.schema.json
@@ -2,6 +2,23 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": false,
   "definitions": {
+    "DockerConfig": {
+      "additionalProperties": false,
+      "description": "Docker runtime options for a stage or the whole pipeline.",
+      "properties": {
+        "volumes": {
+          "description": "Host volumes to bind-mount into the container (`host-path:container-path[:opts]`).",
+          "items": {
+            "type": "string"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        }
+      },
+      "type": "object"
+    },
     "GitIdentity": {
       "description": "Git commit identity mode.",
       "oneOf": [
@@ -92,6 +109,10 @@
     },
     "Stage": {
       "properties": {
+        "docker": {
+          "$ref": "#/definitions/DockerConfig",
+          "description": "Docker runtime options for this stage."
+        },
         "max_failure": {
           "description": "Cap on total failures for this stage, independent of retry counting.",
           "format": "uint32",
@@ -160,6 +181,10 @@
     "commit_as": {
       "$ref": "#/definitions/GitIdentity",
       "description": "Git identity for commits made inside capsules."
+    },
+    "docker": {
+      "$ref": "#/definitions/DockerConfig",
+      "description": "Docker runtime options for all stages."
     },
     "github_token_from": {
       "$ref": "#/definitions/GithubScope",

--- a/src/check.rs
+++ b/src/check.rs
@@ -168,6 +168,7 @@ mod tests {
             max_retries: MAX_RETRIES_DEFAULT,
             max_failure,
             setup: None,
+            volumes: vec![],
         }
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -6,6 +6,15 @@ use std::path::{Path, PathBuf};
 pub const MAX_STAGES_DEFAULT: u32 = 1000;
 pub const MAX_RETRIES_DEFAULT: u32 = 10;
 
+/// Docker runtime options for a stage or the whole pipeline.
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
+#[schemars(rename = "DockerConfig")]
+#[serde(deny_unknown_fields)]
+pub struct DockerConfig {
+    /// Host volumes to bind-mount into the container (`host-path:container-path[:opts]`).
+    pub volumes: Option<Vec<String>>,
+}
+
 /// Git commit identity mode.
 #[derive(Debug, Clone, PartialEq, Deserialize, JsonSchema)]
 #[serde(rename_all = "lowercase")]
@@ -59,6 +68,8 @@ pub struct StageConfig {
     pub max_retries: u32,
     pub max_failure: Option<u32>,
     pub setup: Option<String>,
+    /// Per-stage volumes (raw strings from `docker.volumes`; not yet merged with top-level).
+    pub volumes: Vec<String>,
 }
 
 /// A `loop:` block containing an ordered list of stages.
@@ -98,6 +109,8 @@ pub struct Config {
     pub log_file: Option<PathBuf>,
     /// Host-side setup command or script path, run before any container starts.
     pub setup: Option<String>,
+    /// Top-level volumes from `docker.volumes` in `config.yml`.
+    pub volumes: Vec<String>,
 }
 
 /// CLI-supplied overrides. `None` means "not provided on the command line".
@@ -139,6 +152,8 @@ struct StageConfigRaw {
     max_failure: Option<u32>,
     /// Stage-specific setup command or script path, runs inside the container.
     setup: Option<String>,
+    /// Docker runtime options for this stage.
+    docker: Option<DockerConfig>,
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -189,6 +204,8 @@ struct MultiStageConfigFile {
     log_file: Option<String>,
     /// Host-side setup command or script path, run before any container starts.
     setup: Option<String>,
+    /// Docker runtime options for all stages.
+    docker: Option<DockerConfig>,
 }
 
 // ── Parsing helpers ───────────────────────────────────────────────────────────
@@ -273,6 +290,7 @@ fn convert_stage(raw: StageConfigRaw) -> StageConfig {
         .as_deref()
         .and_then(parse_on_fail)
         .unwrap_or(OnFail::Exit);
+    let volumes = raw.docker.and_then(|d| d.volumes).unwrap_or_default();
     StageConfig {
         name: raw.name,
         prompt: raw.prompt,
@@ -282,6 +300,7 @@ fn convert_stage(raw: StageConfigRaw) -> StageConfig {
         max_retries: raw.max_retries.unwrap_or(MAX_RETRIES_DEFAULT),
         max_failure: raw.max_failure,
         setup: raw.setup,
+        volumes,
     }
 }
 
@@ -414,6 +433,11 @@ pub fn resolve(capsule_dir: &Path, cli: CliOverrides) -> Result<Config> {
     });
     let rebuild = cli.rebuild;
     let setup = file_cfg.as_ref().and_then(|f| f.setup.clone());
+    let volumes = file_cfg
+        .as_ref()
+        .and_then(|f| f.docker.as_ref())
+        .and_then(|d| d.volumes.clone())
+        .unwrap_or_default();
 
     let mut pipeline = if let Some(multi) = file_cfg {
         build_pipeline_from_multi_stage(multi)
@@ -438,6 +462,7 @@ pub fn resolve(capsule_dir: &Path, cli: CliOverrides) -> Result<Config> {
         pipeline,
         log_file,
         setup,
+        volumes,
     })
 }
 
@@ -550,5 +575,120 @@ fn collect_names_from_value(val: &serde_yaml::Value, names: &mut Vec<String>) {
             }
         }
         _ => {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn top_level_docker_volumes_parse() {
+        let yaml = r#"
+stages:
+  - name: a
+    prompt: hi
+docker:
+  volumes:
+    - /host/src:/container/dst
+    - /abs/path:/abs/dst:ro
+"#;
+        let cfg = parse_config_file(yaml).unwrap();
+        let volumes = cfg.docker.unwrap().volumes.unwrap();
+        assert_eq!(
+            volumes,
+            vec!["/host/src:/container/dst", "/abs/path:/abs/dst:ro"]
+        );
+    }
+
+    #[test]
+    fn per_stage_docker_volumes_parse() {
+        let yaml = r#"
+stages:
+  - name: a
+    prompt: hi
+    docker:
+      volumes:
+        - ./data:/data
+"#;
+        let cfg = parse_config_file(yaml).unwrap();
+        let stage = match &cfg.stages[0] {
+            PipelineEntryRaw::Stage(s) => s,
+            _ => panic!("expected stage"),
+        };
+        let volumes = stage.docker.as_ref().unwrap().volumes.as_ref().unwrap();
+        assert_eq!(volumes, &["./data:/data"]);
+    }
+
+    #[test]
+    fn unknown_field_in_docker_block_is_rejected() {
+        let yaml = r#"
+stages:
+  - name: a
+    prompt: hi
+docker:
+  volumes:
+    - /x:/y
+  unknown_option: true
+"#;
+        let err = parse_config_file(yaml).unwrap_err().to_string();
+        assert!(
+            err.contains("unknown") || err.contains("unknown_option"),
+            "expected rejection of unknown docker field, got: {err}"
+        );
+    }
+
+    #[test]
+    fn stage_volumes_stored_in_stage_config() {
+        let yaml = r#"
+stages:
+  - name: a
+    prompt: hi
+    docker:
+      volumes:
+        - ./local:/remote
+"#;
+        let cfg = parse_config_file(yaml).unwrap();
+        let pipeline = build_pipeline_from_multi_stage(cfg).unwrap();
+        let stage = match &pipeline.entries[0] {
+            PipelineEntry::Stage(s) => s,
+            _ => panic!("expected stage"),
+        };
+        assert_eq!(stage.volumes, vec!["./local:/remote"]);
+    }
+
+    #[test]
+    fn absent_docker_volumes_yields_empty_vec() {
+        let yaml = r#"
+stages:
+  - name: a
+    prompt: hi
+"#;
+        let cfg = parse_config_file(yaml).unwrap();
+        let pipeline = build_pipeline_from_multi_stage(cfg).unwrap();
+        let stage = match &pipeline.entries[0] {
+            PipelineEntry::Stage(s) => s,
+            _ => panic!("expected stage"),
+        };
+        assert!(stage.volumes.is_empty());
+    }
+
+    #[test]
+    fn resolve_propagates_top_level_volumes() {
+        let capsule_dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            capsule_dir.path().join("config.yml"),
+            r#"
+stages:
+  - name: a
+    prompt: hi
+docker:
+  volumes:
+    - /host:/container
+"#,
+        )
+        .unwrap();
+        let cfg = resolve(capsule_dir.path(), CliOverrides::default()).unwrap();
+        assert_eq!(cfg.volumes, vec!["/host:/container"]);
     }
 }

--- a/src/container_execution/docker_args.rs
+++ b/src/container_execution/docker_args.rs
@@ -96,8 +96,36 @@ pub fn build_docker_args(
         args.push(network.clone());
     }
 
+    for spec in &cfg.volumes {
+        args.push(format!("-v={}", resolve_volume_src(spec, &cfg.pwd)));
+    }
+
     args.push(cfg.image.clone());
     Ok(args)
+}
+
+/// Resolve a volume spec's source path against `pwd` when it is relative.
+///
+/// Splits on the first `:` to separate `src` from `dst[:opts]`.
+/// Absolute sources pass through unchanged; relative sources are joined with `pwd`.
+/// Specs without `:` (named volumes) are returned as-is.
+fn resolve_volume_src(spec: &str, pwd: &std::path::Path) -> String {
+    match spec.split_once(':') {
+        Some((src, rest)) => {
+            let src_path = std::path::Path::new(src);
+            let resolved = if src_path.is_absolute() {
+                src_path.to_path_buf()
+            } else {
+                // Join then strip CurDir components (`./`) to produce a clean path.
+                pwd.join(src_path)
+                    .components()
+                    .filter(|c| !matches!(c, std::path::Component::CurDir))
+                    .collect::<std::path::PathBuf>()
+            };
+            format!("{}:{}", resolved.display(), rest)
+        }
+        None => spec.to_string(),
+    }
 }
 
 #[cfg(test)]
@@ -652,6 +680,85 @@ mod tests {
         assert!(
             !joined.contains(".credentials.json"),
             "expected no credentials mount when credentials_file is None: {joined}"
+        );
+    }
+
+    #[test]
+    fn volume_flags_emitted_for_configured_volumes() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let prompt_file = tempfile::NamedTempFile::new().unwrap();
+        let cfg = ExecutionConfig {
+            pwd: dir.path().to_path_buf(),
+            volumes: vec!["/abs/src:/abs/dst".to_string(), "/x:/y:ro".to_string()],
+            ..ExecutionConfig::default()
+        };
+        let args = build_docker_args(&cfg, prompt_file.path(), "capsule-test").unwrap();
+        let joined = args.join(" ");
+        assert!(
+            joined.contains("-v=/abs/src:/abs/dst"),
+            "expected absolute volume mount in args: {joined}"
+        );
+        assert!(
+            joined.contains("-v=/x:/y:ro"),
+            "expected read-only volume mount in args: {joined}"
+        );
+    }
+
+    #[test]
+    fn relative_volume_src_resolved_against_workspace() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let prompt_file = tempfile::NamedTempFile::new().unwrap();
+        let cfg = ExecutionConfig {
+            pwd: dir.path().to_path_buf(),
+            volumes: vec!["./data:/container/data".to_string()],
+            ..ExecutionConfig::default()
+        };
+        let args = build_docker_args(&cfg, prompt_file.path(), "capsule-test").unwrap();
+        let joined = args.join(" ");
+        let expected_src = dir.path().join("data");
+        assert!(
+            joined.contains(&format!("-v={}:/container/data", expected_src.display())),
+            "expected relative src resolved to workspace in args: {joined}"
+        );
+    }
+
+    #[test]
+    fn absolute_volume_src_passes_through_unchanged() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let prompt_file = tempfile::NamedTempFile::new().unwrap();
+        let cfg = ExecutionConfig {
+            pwd: dir.path().to_path_buf(),
+            volumes: vec!["/absolute/host:/container/path".to_string()],
+            ..ExecutionConfig::default()
+        };
+        let args = build_docker_args(&cfg, prompt_file.path(), "capsule-test").unwrap();
+        let joined = args.join(" ");
+        assert!(
+            joined.contains("-v=/absolute/host:/container/path"),
+            "expected absolute src unchanged in args: {joined}"
+        );
+    }
+
+    #[test]
+    fn empty_volumes_produces_no_extra_v_flags() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let prompt_file = tempfile::NamedTempFile::new().unwrap();
+        let cfg = ExecutionConfig {
+            pwd: dir.path().to_path_buf(),
+            volumes: vec![],
+            ..ExecutionConfig::default()
+        };
+        let args_with_volumes =
+            build_docker_args(&cfg, prompt_file.path(), "capsule-test").unwrap();
+        let cfg_no_volumes = ExecutionConfig {
+            pwd: dir.path().to_path_buf(),
+            ..ExecutionConfig::default()
+        };
+        let args_no_volumes =
+            build_docker_args(&cfg_no_volumes, prompt_file.path(), "capsule-test").unwrap();
+        assert_eq!(
+            args_with_volumes, args_no_volumes,
+            "empty volumes must not add extra -v flags"
         );
     }
 

--- a/src/container_execution/mod.rs
+++ b/src/container_execution/mod.rs
@@ -60,6 +60,9 @@ pub struct ExecutionConfig {
     /// each other's sessions (issue #55). `None` when the credentials file does not
     /// exist on the host.
     pub credentials_file: Option<PathBuf>,
+    /// Extra host volumes to bind-mount (`host-path:container-path[:opts]`).
+    /// Relative source paths are resolved against `pwd` by `build_docker_args`.
+    pub volumes: Vec<String>,
 }
 
 /// Outcome of a single iteration.

--- a/src/container_execution/runner.rs
+++ b/src/container_execution/runner.rs
@@ -1,4 +1,5 @@
 use anyhow::{Context, Result};
+use std::collections::HashMap;
 use std::io::Write;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
@@ -100,6 +101,9 @@ pub struct DockerStageRunner {
     last_usage_snapshot: Option<UsageSnapshot>,
     credentials_guard: Option<CredentialsGuard>,
     resume_session_id: Option<String>,
+    /// Merged volumes (top-level + per-stage) keyed by stage name.
+    /// Falls back to `base_cfg.volumes` for unknown stage names.
+    stage_volumes: HashMap<String, Vec<String>>,
 }
 
 impl DockerStageRunner {
@@ -108,6 +112,7 @@ impl DockerStageRunner {
         active_container: Arc<Mutex<Option<String>>>,
         credentials_guard: Option<CredentialsGuard>,
         resume_session_id: Option<String>,
+        stage_volumes: HashMap<String, Vec<String>>,
     ) -> Self {
         Self {
             base_cfg,
@@ -118,6 +123,7 @@ impl DockerStageRunner {
             last_usage_snapshot: None,
             credentials_guard,
             resume_session_id,
+            stage_volumes,
         }
     }
 
@@ -145,7 +151,12 @@ impl StageRunner for DockerStageRunner {
             .unwrap_or("unknown");
         crate::display::stage_header(stage_name, self.iteration, effective_model, retry);
         let start = std::time::Instant::now();
-        let result = self.execute_stage(prompt, model, setup);
+        let volumes = self
+            .stage_volumes
+            .get(stage_name)
+            .cloned()
+            .unwrap_or_else(|| self.base_cfg.volumes.clone());
+        let result = self.execute_stage(prompt, model, setup, volumes);
         let duration = start.elapsed();
         crate::display::clear_stage();
         let usage_str = self
@@ -191,6 +202,7 @@ impl DockerStageRunner {
         prompt: &str,
         model: Option<&str>,
         setup: Option<&str>,
+        volumes: Vec<String>,
     ) -> anyhow::Result<Option<Verdict>> {
         let mut cfg = self.base_cfg.clone();
         cfg.prompt = prompt.to_string();
@@ -198,6 +210,7 @@ impl DockerStageRunner {
             cfg.model = Some(m.to_string());
         }
         cfg.setup = setup.map(|s| s.to_string());
+        cfg.volumes = volumes;
         if let Some(session_id) = self.resume_session_id.take() {
             let name = format!("{}-resume-pipeline", container_name_for(self.iteration));
             let (result, status) =

--- a/src/pipeline/mod.rs
+++ b/src/pipeline/mod.rs
@@ -309,6 +309,7 @@ mod tests {
             max_retries: MAX_RETRIES_DEFAULT,
             max_failure: None,
             setup: None,
+            volumes: vec![],
         }
     }
 

--- a/src/run/mod.rs
+++ b/src/run/mod.rs
@@ -197,7 +197,9 @@ impl RunSession {
             compose_network: self.compose_network.clone(),
             claude_dir: self.claude_dir.clone(),
             credentials_file,
+            volumes: self.cfg.volumes.clone(),
         };
+        let stage_volumes = build_stage_volumes(&self.cfg);
         let resume = self.resume.take();
         let resume_session_id = resume.as_ref().map(|(id, _)| id.clone());
         let runner = DockerStageRunner::new(
@@ -205,6 +207,7 @@ impl RunSession {
             Arc::clone(&self.active_container),
             credentials_guard,
             resume_session_id,
+            stage_volumes,
         );
         let (mut result, runner) = if let Some((_, state)) = resume {
             PipelineExecutor::resume(self.cfg.pipeline.clone(), runner, state)
@@ -237,6 +240,29 @@ impl RunSession {
         update_check::maybe_print_notice(update_rx);
         Ok(summary::exit_decision_from_summary(&result.summary))
     }
+}
+
+/// Build a map of stage_name → merged volumes (top-level + per-stage).
+fn build_stage_volumes(cfg: &capsule::config::Config) -> HashMap<String, Vec<String>> {
+    use capsule::config::PipelineEntry;
+    let mut map = HashMap::new();
+    for entry in &cfg.pipeline.entries {
+        match entry {
+            PipelineEntry::Stage(s) => {
+                let mut v = cfg.volumes.clone();
+                v.extend(s.volumes.iter().cloned());
+                map.insert(s.name.clone(), v);
+            }
+            PipelineEntry::Loop(l) => {
+                for s in &l.stages {
+                    let mut v = cfg.volumes.clone();
+                    v.extend(s.volumes.iter().cloned());
+                    map.insert(s.name.clone(), v);
+                }
+            }
+        }
+    }
+    map
 }
 
 fn check_docker() -> Result<()> {

--- a/tests/prompt.rs
+++ b/tests/prompt.rs
@@ -57,6 +57,7 @@ fn single_stage_config(prompt: Option<&str>) -> PipelineConfig {
             max_retries: capsule::config::MAX_RETRIES_DEFAULT,
             max_failure: None,
             setup: None,
+            volumes: vec![],
         })],
         max_stages: 10,
     }
@@ -75,6 +76,7 @@ fn loop_stage_config(prompt: Option<&str>) -> PipelineConfig {
                 max_retries: capsule::config::MAX_RETRIES_DEFAULT,
                 max_failure: None,
                 setup: None,
+                volumes: vec![],
             }],
         })],
         max_stages: 10,

--- a/topics/common-edits.md
+++ b/topics/common-edits.md
@@ -71,6 +71,27 @@ Edit `on_fail:` or `on_pass:` on the relevant stage.
 
 Run `capsule check` after every routing change.
 
+## Mount host volumes
+
+Add a `docker:` block with `volumes:` to bind-mount host directories into containers. Top-level volumes apply to all stages; per-stage volumes are merged on top.
+
+```yaml
+# Top-level: every stage gets these mounts
+docker:
+  volumes:
+    - /host/data:/container/data:ro
+
+stages:
+  - name: main
+    prompt: prompts/main.md
+    # Per-stage: additional mount for this stage only
+    docker:
+      volumes:
+        - ./local:/workspace/local
+```
+
+Relative source paths are resolved against the host workspace. Run `capsule check` after adding volumes.
+
 ## Adjust loop counters
 
 ```yaml

--- a/topics/setup-files.md
+++ b/topics/setup-files.md
@@ -10,6 +10,7 @@ Load before editing any `.capsule/` file — maps each file to its ownership, pu
 | `Dockerfile` | Container OS packages and tools | At image build time |
 | `setup` (top-level) | Host-side setup command or script (optional) | Once on host, before any stage |
 | `setup` (per-stage) | Per-invocation container setup (optional) | Inside each container, before prompt |
+| `docker.volumes` | Host volumes to bind-mount into containers | At `docker run` invocation |
 | `.env` | Env-var defaults and secrets (gitignore) | Sourced on host before top-level `setup` |
 | `prompts/<stage>.md` | Stage prompt content | Mounted into container per invocation |
 
@@ -45,6 +46,28 @@ stages:
     prompt: prompts/main.md
     setup: pip install -r requirements.txt
 ```
+
+## docker.volumes
+
+Bind-mounts host directories into every container invocation. Specified under a `docker:` block at top level (applies to all stages) or per stage (merged on top of top-level volumes).
+
+```yaml
+# Top-level: mounted in every stage
+docker:
+  volumes:
+    - /host/data:/container/data
+    - /host/models:/models:ro
+
+stages:
+  - name: main
+    prompt: prompts/main.md
+    # Per-stage: merged with top-level volumes
+    docker:
+      volumes:
+        - ./local:/workspace/local
+```
+
+Relative source paths (e.g. `./local`) are resolved against the host workspace (`pwd`). Absolute paths pass through unchanged. Format follows Docker's `-v` syntax: `host-path:container-path[:opts]`.
 
 ## .env
 


### PR DESCRIPTION
## Parent
Closes #137

## Summary
Adds a `docker.volumes` config option that lets users bind-mount host directories into capsule containers. Supports top-level (all stages) and per-stage volumes with relative path resolution against the workspace. Unknown fields in the `docker:` block are rejected at config load time.

## Notes
- Volume merge strategy: stage volumes append to top-level volumes, no deduplication.
- Path resolution only applies to the source portion of the volume spec.
- JSON Schema updated to include the new `DockerConfig` definition.