### PR TITLE
Run container as host uid/gid instead of hardcoded uid 1000

### DIFF
--- a/base-image/Dockerfile
+++ b/base-image/Dockerfile
@@ -20,8 +20,8 @@ RUN git config --system core.pager ""
 # preventing agents from overriding commit_as with arbitrary values.
 COPY --chmod=755 git-wrapper.sh /usr/local/bin/git
 
-# Create a non-root user.  UID 1000 matches the typical single-user Arch host,
-# so bind-mounted files are owned by the same UID.
+# Create a non-root user.  UID 1000 is for build-time installation only;
+# runtime uid comes from --user and may differ from 1000.
 RUN useradd -mu 1000 -s /bin/bash claude
 
 USER claude
@@ -30,6 +30,9 @@ ENV NPM_CONFIG_PREFIX=/home/claude/.npm-global
 ENV PATH="/home/claude/.npm-global/bin:${PATH}"
 
 RUN curl -fsSL https://claude.ai/install.sh | bash
+
+# Make home dir world-accessible so the container can run as any uid via --user.
+RUN chmod -R o+rwX /home/claude
 
 ENV PATH="/home/claude/.local/bin:/home/claude/.npm-global/bin:${PATH}"
 ENV CI=true

--- a/base-image/entrypoint.sh
+++ b/base-image/entrypoint.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 set -e
+# Docker's --user doesn't set HOME; pin it so all tools find the right home dir.
+export HOME=/home/claude
 if [ -n "${GH_TOKEN}" ]; then
   git config --global credential.helper store
   echo "https://oauth2:${GH_TOKEN}@github.com" > "${HOME}/.git-credentials"

--- a/src/container_execution/docker_args.rs
+++ b/src/container_execution/docker_args.rs
@@ -91,6 +91,8 @@ pub fn build_docker_args(
         }
     }
 
+    args.push(format!("--user={}:{}", cfg.host_uid, cfg.host_gid));
+
     if let Some(network) = &cfg.compose_network {
         args.push("--network".to_string());
         args.push(network.clone());
@@ -759,6 +761,23 @@ mod tests {
         assert_eq!(
             args_with_volumes, args_no_volumes,
             "empty volumes must not add extra -v flags"
+        );
+    }
+
+    #[test]
+    fn build_docker_args_includes_user_flag_with_uid_gid() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let prompt_file = tempfile::NamedTempFile::new().unwrap();
+        let cfg = ExecutionConfig {
+            pwd: dir.path().to_path_buf(),
+            host_uid: 1234,
+            host_gid: 5678,
+            ..ExecutionConfig::default()
+        };
+        let args = build_docker_args(&cfg, prompt_file.path(), "capsule-test").unwrap();
+        assert!(
+            args.contains(&"--user=1234:5678".to_string()),
+            "expected --user=1234:5678 in docker args: {args:?}"
         );
     }
 

--- a/src/container_execution/mod.rs
+++ b/src/container_execution/mod.rs
@@ -63,6 +63,11 @@ pub struct ExecutionConfig {
     /// Extra host volumes to bind-mount (`host-path:container-path[:opts]`).
     /// Relative source paths are resolved against `pwd` by `build_docker_args`.
     pub volumes: Vec<String>,
+    /// Host user ID passed as `--user uid:gid` so the container process runs as
+    /// the same user as the host, avoiding file-ownership mismatches.
+    pub host_uid: u32,
+    /// Host group ID — paired with `host_uid` for the `--user` flag.
+    pub host_gid: u32,
 }
 
 /// Outcome of a single iteration.

--- a/src/run/mod.rs
+++ b/src/run/mod.rs
@@ -175,6 +175,15 @@ impl RunSession {
         // resume-retry re-copies host credentials.
         let credentials_guard = self.credentials_guard.take();
         let credentials_file = credentials_guard.as_ref().map(|g| g.path().to_path_buf());
+        #[cfg(unix)]
+        let (host_uid, host_gid) = {
+            use std::os::unix::fs::MetadataExt;
+            let meta = std::fs::metadata(&self.pwd)
+                .context("failed to stat workspace to resolve host uid/gid")?;
+            (meta.uid(), meta.gid())
+        };
+        #[cfg(not(unix))]
+        let (host_uid, host_gid) = (0u32, 0u32);
         let base_cfg = ExecutionConfig {
             image: self.image.clone(),
             prompt: String::new(),
@@ -198,6 +207,8 @@ impl RunSession {
             claude_dir: self.claude_dir.clone(),
             credentials_file,
             volumes: self.cfg.volumes.clone(),
+            host_uid,
+            host_gid,
         };
         let stage_volumes = build_stage_volumes(&self.cfg);
         let resume = self.resume.take();

--- a/tests/container_execution.rs
+++ b/tests/container_execution.rs
@@ -412,6 +412,68 @@ fn entrypoint_runs_capsule_stage_setup_when_env_set() {
 #[test]
 #[requires_docker]
 #[serial(base_image)]
+fn entrypoint_runs_before_each_without_executable_bit() {
+    build_base_image(false).expect("base image should be available");
+    build_stub_capsule_image("capsule-before-each-test");
+
+    let dir = tempfile::tempdir().expect("temp dir");
+
+    // Setup script without executable bit — entrypoint uses `bash -c` to run it.
+    let setup_script = dir.path().join("stage-setup.sh");
+    std::fs::write(
+        &setup_script,
+        "#!/bin/bash\necho BEFORE_EACH >> /home/claude/prompt.txt\n",
+    )
+    .unwrap();
+
+    let prompt = dir.path().join("prompt.txt");
+    std::fs::write(&prompt, "ORIGINAL\n").unwrap();
+
+    // Resolve the host uid/gid from the just-created file — no 0o666 workaround needed
+    // because the container runs as the same user via --user uid:gid.
+    #[cfg(unix)]
+    let user_arg = {
+        use std::os::unix::fs::MetadataExt;
+        let meta = std::fs::metadata(&prompt).unwrap();
+        format!("{}:{}", meta.uid(), meta.gid())
+    };
+    #[cfg(not(unix))]
+    let user_arg = "0:0".to_string();
+
+    let _output = std::process::Command::new("docker")
+        .args([
+            "run",
+            "--rm",
+            "--user",
+            &user_arg,
+            "-v",
+            &format!("{}:/home/claude/stage-setup.sh:ro", setup_script.display()),
+            "-v",
+            &format!("{}:/home/claude/prompt.txt", prompt.display()),
+            "-e",
+            "GIT_AUTHOR_NAME=Test",
+            "-e",
+            "GIT_AUTHOR_EMAIL=test@test.com",
+            "-e",
+            "CAPSULE_STAGE_SETUP=/home/claude/stage-setup.sh",
+            "capsule-before-each-test",
+        ])
+        .output()
+        .expect("docker run should succeed");
+
+    let contents =
+        std::fs::read_to_string(&prompt).expect("prompt.txt should be readable after run");
+    assert!(
+        contents.contains("BEFORE_EACH"),
+        "CAPSULE_STAGE_SETUP script should have appended BEFORE_EACH to prompt.txt: {contents:?}"
+    );
+
+    cleanup_image("capsule-before-each-test");
+}
+
+#[test]
+#[requires_docker]
+#[serial(base_image)]
 fn entrypoint_runs_capsule_stage_setup_inline_command() {
     build_base_image(false).expect("base image should be available");
     build_stub_capsule_image("capsule-stage-setup-inline-test");

--- a/tests/container_execution.rs
+++ b/tests/container_execution.rs
@@ -710,11 +710,9 @@ fn extra_env_file_visible_across_stages() {
     };
     let active = Arc::new(Mutex::new(None));
 
-    // Stage 1
     let r1 = run_iteration(&cfg, 1, &active);
     assert!(r1.is_ok(), "stage 1 should not error: {:?}", r1);
 
-    // Stage 2
     let r2 = run_iteration(&cfg, 2, &active);
     assert!(r2.is_ok(), "stage 2 should not error: {:?}", r2);
 

--- a/tests/container_execution.rs
+++ b/tests/container_execution.rs
@@ -372,18 +372,22 @@ fn entrypoint_runs_capsule_stage_setup_when_env_set() {
 
     let prompt = dir.path().join("prompt.txt");
     std::fs::write(&prompt, "ORIGINAL\n").unwrap();
-    // Workaround: container runs as uid 1000 which may differ from the host uid.
-    // Drop once `docker run` passes `--user $(id -u):$(id -g)`.
+
     #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        std::fs::set_permissions(&prompt, std::fs::Permissions::from_mode(0o666)).unwrap();
-    }
+    let user_arg = {
+        use std::os::unix::fs::MetadataExt;
+        let meta = std::fs::metadata(&prompt).unwrap();
+        format!("{}:{}", meta.uid(), meta.gid())
+    };
+    #[cfg(not(unix))]
+    let user_arg = "0:0".to_string();
 
     let _output = std::process::Command::new("docker")
         .args([
             "run",
             "--rm",
+            "--user",
+            &user_arg,
             "-v",
             &format!("{}:/home/claude/stage-setup.sh:ro", setup_script.display()),
             "-v",
@@ -481,16 +485,22 @@ fn entrypoint_runs_capsule_stage_setup_inline_command() {
     let dir = tempfile::tempdir().expect("temp dir");
     let prompt = dir.path().join("prompt.txt");
     std::fs::write(&prompt, "ORIGINAL\n").unwrap();
+
     #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        std::fs::set_permissions(&prompt, std::fs::Permissions::from_mode(0o666)).unwrap();
-    }
+    let user_arg = {
+        use std::os::unix::fs::MetadataExt;
+        let meta = std::fs::metadata(&prompt).unwrap();
+        format!("{}:{}", meta.uid(), meta.gid())
+    };
+    #[cfg(not(unix))]
+    let user_arg = "0:0".to_string();
 
     let _output = std::process::Command::new("docker")
         .args([
             "run",
             "--rm",
+            "--user",
+            &user_arg,
             "-v",
             &format!("{}:/home/claude/prompt.txt", prompt.display()),
             "-e",

--- a/tests/container_execution.rs
+++ b/tests/container_execution.rs
@@ -62,6 +62,20 @@ fn cleanup_image(tag: &str) {
         .output();
 }
 
+fn host_user_arg(path: &std::path::Path) -> String {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+        let meta = std::fs::metadata(path).unwrap();
+        format!("{}:{}", meta.uid(), meta.gid())
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = path;
+        "0:0".to_string()
+    }
+}
+
 #[test]
 fn detect_compose_network_returns_none_when_no_project() {
     let dir = tempfile::tempdir().expect("temp dir");
@@ -373,14 +387,7 @@ fn entrypoint_runs_capsule_stage_setup_when_env_set() {
     let prompt = dir.path().join("prompt.txt");
     std::fs::write(&prompt, "ORIGINAL\n").unwrap();
 
-    #[cfg(unix)]
-    let user_arg = {
-        use std::os::unix::fs::MetadataExt;
-        let meta = std::fs::metadata(&prompt).unwrap();
-        format!("{}:{}", meta.uid(), meta.gid())
-    };
-    #[cfg(not(unix))]
-    let user_arg = "0:0".to_string();
+    let user_arg = host_user_arg(&prompt);
 
     let _output = std::process::Command::new("docker")
         .args([
@@ -433,16 +440,7 @@ fn entrypoint_runs_before_each_without_executable_bit() {
     let prompt = dir.path().join("prompt.txt");
     std::fs::write(&prompt, "ORIGINAL\n").unwrap();
 
-    // Resolve the host uid/gid from the just-created file — no 0o666 workaround needed
-    // because the container runs as the same user via --user uid:gid.
-    #[cfg(unix)]
-    let user_arg = {
-        use std::os::unix::fs::MetadataExt;
-        let meta = std::fs::metadata(&prompt).unwrap();
-        format!("{}:{}", meta.uid(), meta.gid())
-    };
-    #[cfg(not(unix))]
-    let user_arg = "0:0".to_string();
+    let user_arg = host_user_arg(&prompt);
 
     let _output = std::process::Command::new("docker")
         .args([
@@ -486,14 +484,7 @@ fn entrypoint_runs_capsule_stage_setup_inline_command() {
     let prompt = dir.path().join("prompt.txt");
     std::fs::write(&prompt, "ORIGINAL\n").unwrap();
 
-    #[cfg(unix)]
-    let user_arg = {
-        use std::os::unix::fs::MetadataExt;
-        let meta = std::fs::metadata(&prompt).unwrap();
-        format!("{}:{}", meta.uid(), meta.gid())
-    };
-    #[cfg(not(unix))]
-    let user_arg = "0:0".to_string();
+    let user_arg = host_user_arg(&prompt);
 
     let _output = std::process::Command::new("docker")
         .args([

--- a/tests/container_execution.rs
+++ b/tests/container_execution.rs
@@ -423,59 +423,6 @@ fn entrypoint_runs_capsule_stage_setup_when_env_set() {
 #[test]
 #[requires_docker]
 #[serial(base_image)]
-fn entrypoint_runs_before_each_without_executable_bit() {
-    build_base_image(false).expect("base image should be available");
-    build_stub_capsule_image("capsule-before-each-test");
-
-    let dir = tempfile::tempdir().expect("temp dir");
-
-    // Setup script without executable bit — entrypoint uses `bash -c` to run it.
-    let setup_script = dir.path().join("stage-setup.sh");
-    std::fs::write(
-        &setup_script,
-        "#!/bin/bash\necho BEFORE_EACH >> /home/claude/prompt.txt\n",
-    )
-    .unwrap();
-
-    let prompt = dir.path().join("prompt.txt");
-    std::fs::write(&prompt, "ORIGINAL\n").unwrap();
-
-    let user_arg = host_user_arg(&prompt);
-
-    let _output = std::process::Command::new("docker")
-        .args([
-            "run",
-            "--rm",
-            "--user",
-            &user_arg,
-            "-v",
-            &format!("{}:/home/claude/stage-setup.sh:ro", setup_script.display()),
-            "-v",
-            &format!("{}:/home/claude/prompt.txt", prompt.display()),
-            "-e",
-            "GIT_AUTHOR_NAME=Test",
-            "-e",
-            "GIT_AUTHOR_EMAIL=test@test.com",
-            "-e",
-            "CAPSULE_STAGE_SETUP=/home/claude/stage-setup.sh",
-            "capsule-before-each-test",
-        ])
-        .output()
-        .expect("docker run should succeed");
-
-    let contents =
-        std::fs::read_to_string(&prompt).expect("prompt.txt should be readable after run");
-    assert!(
-        contents.contains("BEFORE_EACH"),
-        "CAPSULE_STAGE_SETUP script should have appended BEFORE_EACH to prompt.txt: {contents:?}"
-    );
-
-    cleanup_image("capsule-before-each-test");
-}
-
-#[test]
-#[requires_docker]
-#[serial(base_image)]
 fn entrypoint_runs_capsule_stage_setup_inline_command() {
     build_base_image(false).expect("base image should be available");
     build_stub_capsule_image("capsule-stage-setup-inline-test");


### PR DESCRIPTION
## Parent
Closes #187

## Summary
Passes the host user's uid/gid via `--user` to `docker run` so bind-mounted files are accessible regardless of the host uid. Updates the base image and entrypoint to support arbitrary-uid runtime while keeping the build-time `claude` user for installation.

## Notes
- Removes the `0o666` permission workaround from integration tests — the `--user` flag makes it unnecessary.
- Non-unix platforms fall back to `0:0`.